### PR TITLE
fix: fail-soft Firebase init so missing config degrades to guest mode

### DIFF
--- a/docs/adr/0002-firebase-fail-soft-guest-mode.md
+++ b/docs/adr/0002-firebase-fail-soft-guest-mode.md
@@ -1,0 +1,15 @@
+# Firebase initializes fail-soft; the app degrades to guest mode on missing config
+
+`src/lib/firebase.ts` checks the `NEXT_PUBLIC_FIREBASE_*` config before initializing. If it's absent, it does NOT call `initializeApp`/`getAuth`/`getFirestore`; it exports `auth = null`, `db = null`, and `isFirebaseConfigured = false`. Consumers guard those nullable exports, so a misconfigured deployment runs in **guest-only mode** (driving works; sign-in and history show "temporarily unavailable") instead of crashing.
+
+## Why (the non-obvious part)
+Firebase init throws `auth/invalid-api-key` at **module-evaluation time** when the API key is undefined. `ClientApp` already has a React `ErrorBoundary`, but boundaries only catch errors thrown *while rendering their children* — an error thrown as a module is imported happens before any boundary mounts, so it escapes to Next.js's global handler and white-screens the entire app (observed: `driving-sigma.vercel.app` "Application error"). The only place to stop it is the init site itself: don't throw at import.
+
+## Considered Options
+- **Fail-fast (status quo)** — let init throw. Rejected: a single missing env var takes down the whole app for every user, including the core driving game that doesn't need Firebase at all.
+- **Whole-app "service unavailable" gate** — render one error screen when unconfigured. Simpler, but also blocks guest driving during an outage.
+- **Fail-soft to guest mode (chosen)** — preserve the core experience; only auth/history surfaces degrade. The app already supported guest play, so this keeps the most value with the least user-visible loss.
+
+## Consequences
+- `auth` and `db` are `Auth | null` / `Firestore | null`; the type system now forces every consumer to guard them, which prevents re-introducing the crash.
+- This is a resilience layer, not a substitute for configuration: the real fix is still setting the env vars (plan 0002). Without them, sign-in and history remain unavailable — failure is now visible and contained rather than catastrophic.

--- a/docs/superpowers/plans/0002-firebase-env-config-prod-crash.md
+++ b/docs/superpowers/plans/0002-firebase-env-config-prod-crash.md
@@ -1,0 +1,43 @@
+# Plan 0002 — Firebase env config & production crash fix
+
+Status: ROOT CAUSE CONFIRMED 2026-06-20; fix not yet applied.
+Severity: **production outage** — `driving-sigma.vercel.app` hard-crashes on load for all users.
+
+## Symptom
+Loading `driving-sigma.vercel.app` shows "Application error: a client-side exception has occurred." Browser console:
+```
+Uncaught FirebaseError: Firebase: Error (auth/invalid-api-key).
+  ... at eE.initialize ... popupRedirectResolver ... module evaluation
+```
+The throw happens during `getAuth` initialization, at module evaluation (import) time.
+
+## Root cause (confirmed, not assumed)
+`firebase.ts` initializes Firebase at IMPORT time — `initializeApp` / `getAuth` / `getFirestore` run on module load ([firebase.ts:15-19](src/lib/firebase.ts#L15)). The config comes entirely from `NEXT_PUBLIC_FIREBASE_*` env vars ([firebase.ts:5-12](src/lib/firebase.ts#L5)), which Next.js **inlines at build time**. Vercel has no env vars (Production project scope shows "No Environment Variables Added") and no `.env*` file exists in the repo, so the production build baked in `undefined`. `getAuth()` with an undefined `apiKey` throws `auth/invalid-api-key`; because `firebase.ts` is imported by components, the throw crashes the entire app. The console error names `auth/invalid-api-key` explicitly, so this is the cause, not an unrelated client bug.
+
+## The six values — source of truth is the Firebase console
+Firebase console → Project Settings → General → "Your apps" → SDK setup and configuration. Map `firebaseConfig` → env var:
+| firebaseConfig key | env var |
+|---|---|
+| `apiKey` | `NEXT_PUBLIC_FIREBASE_API_KEY` |
+| `authDomain` | `NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN` |
+| `projectId` | `NEXT_PUBLIC_FIREBASE_PROJECT_ID` (must be `driving-school-e862d`) |
+| `storageBucket` | `NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET` |
+| `messagingSenderId` | `NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID` |
+| `appId` | `NEXT_PUBLIC_FIREBASE_APP_ID` |
+
+These are **public config**, not secrets — they ship in the client bundle by design; a Firebase web API key is an identifier, and security comes from rules + auth (plan 0001), not from hiding it. No Vercel "Sensitive" flag needed. If "Your apps" has no web app registered, register a Web app first to obtain the config.
+
+## Fix
+1. Copy the six values from the Firebase console (table above).
+2. **Local dev**: create `.env.local` at repo root (gitignored via `.env*`) with the six `NEXT_PUBLIC_FIREBASE_*=...` lines. Enables `npm run dev` and plan 0001's Phase D.
+3. **Production**: add the six vars in Vercel → Settings → Environment Variables, scoped to **Production + Preview** (Development not needed — local uses `.env.local`, not `vercel dev`).
+4. **REDEPLOY — the step that's easy to miss**: `NEXT_PUBLIC_*` inlines at BUILD time, so adding the vars does NOT fix the current live deployment. Trigger a new build: Vercel → Deployments → Redeploy (rebuilds and re-inlines), or push a commit. The site stays broken until a fresh build runs.
+5. **Verify**: reload `driving-sigma.vercel.app` → no crash, login works. History also needs the composite index (plan 0001's Index section).
+
+## Sequencing vs plan 0001
+Independent of, and a prerequisite for, plan 0001's Phase D — you cannot functionally test the rules against an app that won't run. Do this first. (The rules *deploy* doesn't need the app running; *verifying* it does.)
+
+## Hardening — DONE (2026-06-20, ADR-0002)
+`firebase.ts` no longer crashes the app when config is missing. It now checks `isFirebaseConfigured`, skips init when the config is absent, and exports `auth`/`db` as nullable; the app degrades to **guest mode** (driving works; sign-in and history show "temporarily unavailable"). Consumers guard the nullable exports (`AuthScreen`, `ClientApp`, `FeedbackScreen`, `HistoryScreen`). Verified: `tsc --noEmit` clean and `npm run build` succeeds with NO env vars present (previously the crash-producing condition). Rationale and the rejected alternatives are in `docs/adr/0002-firebase-fail-soft-guest-mode.md`.
+
+This hardening contains the blast radius; it is NOT a substitute for the fix above. Until the env vars are set and the app redeployed, production runs guest-only (no login, no history).

--- a/src/components/ClientApp.tsx
+++ b/src/components/ClientApp.tsx
@@ -29,7 +29,7 @@ function UserProfileHeader() {
     if (screen === 'driving' || screen === 'feedback' || screen === 'auth' || screen === 'history') return null;
 
     const handleLogout = async () => {
-        await auth.signOut();
+        if (auth) await auth.signOut();
         setUser(null);
         setMissionHistory([]);
     }

--- a/src/components/auth/AuthScreen.tsx
+++ b/src/components/auth/AuthScreen.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react';
 import { useDrivingStore } from '@/lib/store';
-import { auth } from '@/lib/firebase';
+import { auth, isFirebaseConfigured } from '@/lib/firebase';
 import { createUserWithEmailAndPassword, signInWithEmailAndPassword } from 'firebase/auth';
 
 export function AuthScreen() {
@@ -19,7 +19,13 @@ export function AuthScreen() {
     e.preventDefault();
     setError('');
     setLoading(true);
-    
+
+    if (!auth) {
+      setError('現在ログイン機能を利用できません。ゲストとしてご利用ください。');
+      setLoading(false);
+      return;
+    }
+
     try {
       let userCredential;
       if (isRegistering) {
@@ -47,6 +53,29 @@ export function AuthScreen() {
       setLoading(false);
     }
   };
+
+  // Fail soft: Firebase is not configured on this deployment, so sign-in cannot
+  // work. Don't render the form (it would call auth APIs with a null client);
+  // offer guest play instead.
+  if (!isFirebaseConfigured) {
+    return (
+      <div className="w-full h-full flex items-center justify-center bg-slate-900 text-white">
+        <div className="bg-slate-800 p-8 rounded-xl border border-slate-700 w-96 shadow-2xl text-center">
+          <h2 className="text-2xl font-bold mb-4 text-blue-400">🚗 ログイン</h2>
+          <p className="text-slate-300 mb-6 leading-relaxed">
+            現在サインイン機能を一時的にご利用いただけません。<br />
+            ゲストとして練習を続けられます。
+          </p>
+          <button
+            onClick={() => setScreen('home')}
+            className="w-full py-3 bg-blue-600 hover:bg-blue-500 rounded font-bold transition-colors"
+          >
+            ゲストとして続ける
+          </button>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="w-full h-full flex items-center justify-center bg-slate-900 text-white">

--- a/src/components/ui/FeedbackScreen.tsx
+++ b/src/components/ui/FeedbackScreen.tsx
@@ -44,6 +44,7 @@ export function FeedbackScreen() {
   }, []);
 
   const saveResultToFirestore = async ( state: any) => {
+    if (!db) return; // guest-only mode: nothing to persist to
     try {
         const kaizenLogs = state.feedbackLogs.filter((l: any) => l.type === 'KAIZEN');
         const kaizenPenalty = kaizenLogs.reduce((acc: number, l: any) => acc + (l.meta?.penalty ?? 5), 0);

--- a/src/components/ui/HistoryScreen.tsx
+++ b/src/components/ui/HistoryScreen.tsx
@@ -15,7 +15,7 @@ export function HistoryScreen() {
 
   useEffect(() => {
     async function fetchHistory() {
-      if (!user) {
+      if (!user || !db) {
         setLoading(false);
         return;
       }

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -1,6 +1,6 @@
 import { initializeApp, getApps, getApp } from "firebase/app";
-import { getAuth } from "firebase/auth";
-import { getFirestore } from "firebase/firestore";
+import { getAuth, type Auth } from "firebase/auth";
+import { getFirestore, type Firestore } from "firebase/firestore";
 
 const firebaseConfig = {
   apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY,
@@ -11,11 +11,43 @@ const firebaseConfig = {
   appId: process.env.NEXT_PUBLIC_FIREBASE_APP_ID,
 };
 
-// アプリの二重初期化を防ぐ
-const app = !getApps().length ? initializeApp(firebaseConfig) : getApp();
+// Fail soft. If the public Firebase config is missing (e.g. the
+// NEXT_PUBLIC_FIREBASE_* env vars were never set on this deployment), DO NOT
+// initialize at import time: initializeApp/getAuth with an undefined apiKey
+// throws `auth/invalid-api-key` during module evaluation, which crashes the
+// whole app BEFORE any React error boundary can mount (boundaries only catch
+// render-time errors, not import-time ones). So instead we export nulls plus a
+// flag, letting the app run in guest mode while the auth/history surfaces show
+// "temporarily unavailable". See docs/adr/0002 and
+// docs/superpowers/plans/0002-firebase-env-config-prod-crash.md.
+export const isFirebaseConfigured = Boolean(
+  firebaseConfig.apiKey &&
+    firebaseConfig.authDomain &&
+    firebaseConfig.projectId &&
+    firebaseConfig.appId,
+);
 
-// AuthとFirestoreのインスタンスをエクスポート
-const auth = getAuth(app);
-const db = getFirestore(app);
+let auth: Auth | null = null;
+let db: Firestore | null = null;
+
+if (isFirebaseConfigured) {
+  try {
+    const app = !getApps().length ? initializeApp(firebaseConfig) : getApp();
+    auth = getAuth(app);
+    db = getFirestore(app);
+  } catch (e) {
+    // Defensive: any unexpected init failure also degrades to guest mode
+    // rather than taking down the app.
+    console.error("[firebase] initialization failed; running in guest-only mode.", e);
+    auth = null;
+    db = null;
+  }
+} else {
+  console.warn(
+    "[firebase] NEXT_PUBLIC_FIREBASE_* env vars are missing; running in guest-only mode. " +
+      "Set them in .env.local (local dev) and Vercel (deploy), then redeploy. " +
+      "See docs/superpowers/plans/0002-firebase-env-config-prod-crash.md",
+  );
+}
 
 export { auth, db };


### PR DESCRIPTION
## What & why

Production (`driving-sigma.vercel.app`) white-screened on load with:

`Uncaught FirebaseError: Firebase: Error (auth/invalid-api-key)`

`firebase.ts` initialized Firebase at **module-import time**, so when the `NEXT_PUBLIC_FIREBASE_*` env vars are absent (none are set on Vercel today), `getAuth()` threw during module evaluation and crashed the whole React tree. `ClientApp`'s `ErrorBoundary` cannot catch this — boundaries only catch render-time errors, not import-time throws.

## Change

Initialize **fail-soft**:
- `firebase.ts` checks the config first, skips init when it is missing, and exports `auth`/`db` as nullable plus an `isFirebaseConfigured` flag.
- The app degrades to **guest mode**: driving still works; `AuthScreen` shows a "sign-in temporarily unavailable / continue as guest" card; history is unavailable.
- The nullable types force every consumer (`AuthScreen`, `ClientApp`, `FeedbackScreen`, `HistoryScreen`) to guard the values, so the crash cannot silently return.

## Scope / follow-up

This **contains** the outage; it is not the full fix. Login and history stay unavailable until the six `NEXT_PUBLIC_FIREBASE_*` values are set in Vercel + `.env.local` and the app is redeployed. Tracked in `docs/superpowers/plans/0002-firebase-env-config-prod-crash.md`; rationale in `docs/adr/0002-firebase-fail-soft-guest-mode.md`.

## Verification

- `tsc --noEmit` clean
- `npm run build` succeeds with **no env vars present** (the exact crash condition)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
