### PR TITLE
feat: first-launch language-selection page (English)

### DIFF
--- a/docs/superpowers/plans/0005-i18n-ja-en.md
+++ b/docs/superpowers/plans/0005-i18n-ja-en.md
@@ -3,7 +3,8 @@
 Status: IMPLEMENTED 2026-06-21 (branch `feat/i18n-ja-en`). Verified by `tsc --noEmit` + `npm run build` (both clean). Real-world check (toggle JA/EN in the running app) still recommended.
 
 ## Decisions
-- **Language switcher: Home only.** A JA/EN toggle in the Home screen's top bar. No dedicated first-launch screen. Default **Japanese**; choice persisted to `localStorage`.
+- **Language switcher: Home toggle.** A JA/EN toggle in the Home screen's top bar. Default **Japanese**; choice persisted to `localStorage`.
+- **First-launch language page (added 2026-06-21, revising the earlier "Home only" decision).** On first visit (no saved language) the app opens on a dedicated `LanguageScreen` (a new `screen: 'language'`), **presented in English** ("Select your language" with 日本語 / English buttons). Choosing persists the language and routes to Home; returning visitors skip it and go straight to Home. Routing is driven from the store's `screen` init reading `localStorage` — safe because `ClientApp` is `ssr:false` (client-only), so there's no hydration mismatch. The Home toggle remains for changing language later.
 - **Comments: all translated to English.** Every Japanese code comment (and dev-facing debug/log string) across the codebase is now English. This was in scope per the user's request, separate from the user-facing toggle.
 
 ## Pattern (chosen for parallel-safe conversion)

--- a/src/components/ClientApp.tsx
+++ b/src/components/ClientApp.tsx
@@ -12,6 +12,7 @@ import { AuthScreen } from '@/components/auth/AuthScreen';
 import { HistoryScreen } from '@/components/ui/HistoryScreen';
 import { auth } from '@/lib/firebase';
 import { TutorialScreen } from '@/components/ui/TutorialScreen';
+import { LanguageScreen } from '@/components/ui/LanguageScreen';
 
 const VisionController = dynamic(() => import('@/components/vision/VisionController'), { ssr: false });
 const Scene = dynamic(() => import('@/components/simulation/Scene').then(mod => mod.Scene), { ssr: false });
@@ -26,7 +27,7 @@ function UserProfileHeader() {
     // This could get in the way during driving or on the feedback screen, so we could limit it
     // to HOME only. For now it stays visible at all times; we could also make it less prominent
     // while driving, but per the requirements it is placed in the top-right corner.
-    if (screen === 'driving' || screen === 'feedback' || screen === 'auth' || screen === 'history') return null;
+    if (screen === 'driving' || screen === 'feedback' || screen === 'auth' || screen === 'history' || screen === 'language') return null;
 
     const handleLogout = async () => {
         if (auth) await auth.signOut();
@@ -261,6 +262,7 @@ export default function ClientApp() {
             </div>
           )}
 
+          {screen === 'language' && <LanguageScreen />}
           {screen === 'home' && <HomeScreen />}
           {screen === 'auth' && <AuthScreen />}
           {screen === 'history' && <HistoryScreen />}

--- a/src/components/ui/LanguageScreen.tsx
+++ b/src/components/ui/LanguageScreen.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { useDrivingStore } from "@/lib/store";
+
+// First-launch language selection page. Presented in English. It is shown only
+// when no language has been chosen yet (see the `screen` init in store.ts);
+// choosing a language persists it and proceeds to Home, and returning visitors
+// skip this page. See docs/superpowers/plans/0005-i18n-ja-en.md.
+export function LanguageScreen() {
+  const setLanguage = useDrivingStore((s) => s.setLanguage);
+  const setScreen = useDrivingStore((s) => s.setScreen);
+
+  const choose = (lang: "ja" | "en") => {
+    setLanguage(lang);
+    setScreen("home");
+  };
+
+  return (
+    <div className="w-full h-full flex flex-col items-center justify-center bg-slate-900 text-white">
+      <div className="text-center px-6">
+        <h1 className="text-4xl font-extrabold italic tracking-tight mb-2">
+          VIRTUAL <span className="text-blue-500">DRIVING</span> SCHOOL
+        </h1>
+        <p className="text-slate-400 mb-10 tracking-wide">Select your language</p>
+
+        <div className="flex gap-4 justify-center">
+          <button
+            onClick={() => choose("ja")}
+            className="w-48 py-5 bg-slate-800 hover:bg-blue-600 border border-slate-700 hover:border-blue-500 rounded-xl text-xl font-bold transition-colors"
+          >
+            日本語
+            <span className="block text-xs font-normal text-slate-400 mt-1">Japanese</span>
+          </button>
+          <button
+            onClick={() => choose("en")}
+            className="w-48 py-5 bg-slate-800 hover:bg-blue-600 border border-slate-700 hover:border-blue-500 rounded-xl text-xl font-bold transition-colors"
+          >
+            English
+            <span className="block text-xs font-normal text-slate-400 mt-1">英語</span>
+          </button>
+        </div>
+
+        <p className="text-slate-600 text-xs mt-8">You can change this later from the Home screen.</p>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -61,7 +61,7 @@ export type LessonId =
   | "crosswalk"
   | "railroad-crossing";
 
-export type ScreenId = "home" | "driving" | "feedback" | "auth" | "history" | "tutorial";
+export type ScreenId = "home" | "driving" | "feedback" | "auth" | "history" | "tutorial" | "language";
 export type MissionState = "idle" | "briefing" | "active" | "success" | "failed";
 
 export interface DrivingState {
@@ -167,7 +167,13 @@ export interface DrivingState {
 }
 
 export const useDrivingStore = create<DrivingState>((set) => ({
-  screen: "home",
+  // First launch (no saved language) starts on the language-selection page;
+  // returning visitors (saved choice) go straight to Home. ClientApp is
+  // client-only (ssr:false), so reading localStorage here is safe.
+  screen:
+    typeof window !== "undefined" && localStorage.getItem("language")
+      ? "home"
+      : "language",
   isPaused: false,
   language:
     typeof window !== "undefined" && localStorage.getItem("language") === "en"


### PR DESCRIPTION
## What

Adds the dedicated **first-launch language-selection page** that was missing — the earlier i18n shipped only a Home toggle.

## Behavior

- **First visit** (no saved language): the app opens on a new `LanguageScreen`, **presented in English** ("Select your language" with `日本語` / `English` buttons).
- Choosing a language persists it (`localStorage`) and routes to Home in that language.
- **Returning visitors** skip the page and go straight to Home.
- The Home `JA/EN` toggle stays for changing language later.

## How

- `store`: new `screen: 'language'`; the initial screen is `'language'` when no language is saved, else `'home'`. Safe to read `localStorage` in the store init because `ClientApp` is `ssr:false` (client-only) — no hydration mismatch.
- `LanguageScreen` component (English-presented).
- `ClientApp`: routes the new screen and hides the profile header on it.

## Verification

`tsc --noEmit` clean; `npm run build` clean. Worth a manual check: clear the `language` key in `localStorage` (or use a fresh browser) to see the first-launch page.

See `docs/superpowers/plans/0005-i18n-ja-en.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
