### PR TITLE
test(simulation): add deterministic guided training regression coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npm run lint
+      - run: npm run test:guided
       - run: npm run type-check
 
   build-smoke:

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+.test-dist/
 
 # vercel
 .vercel

--- a/docs/logs/2026-08/ISSUE-31-guided-training-regression.md
+++ b/docs/logs/2026-08/ISSUE-31-guided-training-regression.md
@@ -1,0 +1,41 @@
+# Issue
+
+Issue #31 — Define deterministic guided training slice and scoring regression cases
+
+## Date
+
+2026-08-13 JST
+
+## Objective
+
+Make the smallest existing guided-training slice verifiable without webcam, Firebase, network, time, or randomness dependencies.
+
+## Selected slice
+
+The existing `left-turn` lesson: `stop-1` followed by `mirror-1`, then the existing left-turn goal and result flow.
+
+## Regression cases
+
+- Successful run: clears both checkpoints in order; expects pass, score 100, and no feedback.
+- Missed checkpoint: clears only `stop-1`; expects score 80 and feedback naming `mirror-1`.
+- Retry reset: resets a completed run; expects no cleared checkpoints and the base score of 60 for two required checkpoints.
+- Keyboard pedal fallback: runs the same sequence with `pedalInputMode = keyboard`; expects score 100 without camera state.
+- Additional order guard: an out-of-order `mirror-1` event cannot bypass `stop-1`.
+
+## Technical decisions
+
+- Use Node's built-in `node:test` runner; no E2E framework or browser dependency is added.
+- Add a small dependency-free TypeScript contract seam rather than importing the React/Zustand/Firebase runtime into tests.
+- Keep runtime scoring and course definitions unchanged.
+
+## Testability seams
+
+`src/lib/guidedTrainingContract.ts` contains deterministic checkpoint ordering, penalty/result calculation, feedback identifiers, and retry reset behavior. It is deliberately independent of camera, Firebase, Three.js, time, and randomness.
+
+## Verification
+
+`npm ci`, `npm run lint`, `npm run type-check`, `npm run test:guided`, and `git diff --check` are required before PR.
+
+## Remaining risks
+
+The seam verifies the documented guided-training contract, while full runtime integration still needs manual/browser validation in a later issue. It does not test MediaPipe, camera permissions, or Firebase.

--- a/docs/logs/2026-08/ISSUE-31-guided-training-regression.md
+++ b/docs/logs/2026-08/ISSUE-31-guided-training-regression.md
@@ -12,25 +12,30 @@ Make the smallest existing guided-training slice verifiable without webcam, Fire
 
 ## Selected slice
 
-The existing `left-turn` lesson: `stop-1` followed by `mirror-1`, then the existing left-turn goal and result flow.
+The existing `left-turn` lesson with `stop-1` and `mirror-1`, then the existing goal and result flow.
+
+## PM review finding and correction
+
+The first draft tested an independent model that enforced checkpoint ordering and invented mirror feedback. That could pass while production behaved differently. The correction removed that model and extracted helpers from existing production behavior.
+
+`store.ts` now uses the shared missed-ID, penalty, and feedback helpers. `FeedbackScreen.tsx` uses the shared score and retry-transition helpers. Runtime behavior is preserved.
 
 ## Regression cases
 
-- Successful run: clears both checkpoints in order; expects pass, score 100, and no feedback.
-- Missed checkpoint: clears only `stop-1`; expects score 80 and feedback naming `mirror-1`.
-- Retry reset: resets a completed run; expects no cleared checkpoints and the base score of 60 for two required checkpoints.
-- Keyboard pedal fallback: runs the same sequence with `pedalInputMode = keyboard`; expects score 100 without camera state.
-- Additional order guard: an out-of-order `mirror-1` event cannot bypass `stop-1`.
+- Successful result: both existing checkpoints are cleared; expects no missed penalty and score 100.
+- Missed checkpoint: only `stop-1` is cleared; expects the existing 20-point penalty. `mirror-1` produces no missed feedback because that is current production behavior.
+- Retry transition: expects the existing `briefing`/`driving` transition after replay data is cleared.
+- Keyboard pedal fallback: uses the same shared checkpoint/score helpers; pedal input mode does not alter scoring.
 
 ## Technical decisions
 
 - Use Node's built-in `node:test` runner; no E2E framework or browser dependency is added.
-- Add a small dependency-free TypeScript contract seam rather than importing the React/Zustand/Firebase runtime into tests.
+- Extract small dependency-free helpers from production rather than maintaining a test-only copy.
 - Keep runtime scoring and course definitions unchanged.
 
 ## Testability seams
 
-`src/lib/guidedTrainingContract.ts` contains deterministic checkpoint ordering, penalty/result calculation, feedback identifiers, and retry reset behavior. It is deliberately independent of camera, Firebase, Three.js, time, and randomness.
+`src/lib/guidedTrainingContract.ts` contains the shared missed-checkpoint, penalty, final-score, feedback, and retry-transition helpers. It is independent of camera, Firebase, Three.js, time, and randomness.
 
 ## Verification
 
@@ -38,4 +43,4 @@ The existing `left-turn` lesson: `stop-1` followed by `mirror-1`, then the exist
 
 ## Remaining risks
 
-The seam verifies the documented guided-training contract, while full runtime integration still needs manual/browser validation in a later issue. It does not test MediaPipe, camera permissions, or Firebase.
+The tests verify helpers imported by production, while full runtime integration still needs manual/browser validation in a later issue. The lack of missed mirror feedback is an existing behavior mismatch/follow-up candidate, not changed by Issue #31.

--- a/docs/logs/2026-08/ISSUE-31-guided-training-regression.md
+++ b/docs/logs/2026-08/ISSUE-31-guided-training-regression.md
@@ -20,6 +20,8 @@ The first draft tested an independent model that enforced checkpoint ordering an
 
 `store.ts` now uses the shared missed-ID, penalty, and feedback helpers. `FeedbackScreen.tsx` uses the shared score and retry-transition helpers. Runtime behavior is preserved.
 
+The left-turn checkpoint definition was also moved to the dependency-light `src/lib/missionCheckpoints.ts`. `MissionController.tsx` re-exports it for existing consumers, and the regression tests import the shared definition directly so checkpoint ID changes cannot silently leave the tests stale. The guided regression command is enforced in the existing quality job in `.github/workflows/ci.yml`.
+
 ## Regression cases
 
 - Successful result: both existing checkpoints are cleared; expects no missed penalty and score 100.
@@ -35,7 +37,7 @@ The first draft tested an independent model that enforced checkpoint ordering an
 
 ## Testability seams
 
-`src/lib/guidedTrainingContract.ts` contains the shared missed-checkpoint, penalty, final-score, feedback, and retry-transition helpers. It is independent of camera, Firebase, Three.js, time, and randomness.
+`src/lib/guidedTrainingContract.ts` contains the shared missed-checkpoint, penalty, final-score, feedback, and retry-transition helpers. `src/lib/missionCheckpoints.ts` contains the shared mission checkpoint data. Both are independent of camera, Firebase, Three.js, time, and randomness.
 
 ## Verification
 

--- a/docs/product/GUIDED_TRAINING_CONTRACT.md
+++ b/docs/product/GUIDED_TRAINING_CONTRACT.md
@@ -1,0 +1,23 @@
+# Guided training regression contract
+
+Issue #31 uses the existing `left-turn` lesson as the smallest deterministic guided-training slice.
+
+## Existing runtime slice
+
+- Course path: `src/lib/course.ts`, `left-turn`.
+- Required checkpoints: `stop-1` at the stop line, then `mirror-1` for the safety check, from `src/components/simulation/MissionController.tsx`.
+- Goal: the existing left-turn goal in `MISSION_GOALS`.
+- Runtime scoring and checkpoint penalties remain in `src/lib/store.ts` and the simulation components.
+- Retry remains the existing `FeedbackScreen.tsx` flow, which clears replay data and returns to driving briefing.
+
+## Deterministic contract
+
+The dependency-free seam in `src/lib/guidedTrainingContract.ts` models only the observable contract needed for regression coverage:
+
+1. `stop-1` must be cleared before `mirror-1`.
+2. A complete sequence passes with score 100 and no feedback.
+3. Each missed checkpoint costs 20 points and reports its checkpoint ID.
+4. Retry starts with no cleared checkpoints while preserving the selected pedal input mode.
+5. Keyboard pedal mode uses the same checkpoint/result contract and does not require camera or Firebase state.
+
+This is a testability seam, not a new lesson or a scoring-rule change. The production runtime remains the source of behavior and is not rewritten by Issue #31.

--- a/docs/product/GUIDED_TRAINING_CONTRACT.md
+++ b/docs/product/GUIDED_TRAINING_CONTRACT.md
@@ -5,19 +5,19 @@ Issue #31 uses the existing `left-turn` lesson as the smallest deterministic gui
 ## Existing runtime slice
 
 - Course path: `src/lib/course.ts`, `left-turn`.
-- Required checkpoints: `stop-1` at the stop line, then `mirror-1` for the safety check, from `src/components/simulation/MissionController.tsx`.
+- Checkpoints: `stop-1` and `mirror-1`, from `src/components/simulation/MissionController.tsx`.
 - Goal: the existing left-turn goal in `MISSION_GOALS`.
-- Runtime scoring and checkpoint penalties remain in `src/lib/store.ts` and the simulation components.
-- Retry remains the existing `FeedbackScreen.tsx` flow, which clears replay data and returns to driving briefing.
+- Runtime scoring and checkpoint penalties are implemented in `src/lib/store.ts`.
+- Retry remains the existing `FeedbackScreen.tsx` flow: clear replay data, set mission state to `briefing`, and show `driving`.
 
-## Deterministic contract
+## Current behavior extracted for testing
 
-The dependency-free seam in `src/lib/guidedTrainingContract.ts` models only the observable contract needed for regression coverage:
+The helpers in `src/lib/guidedTrainingContract.ts` are imported by production `store.ts` and `FeedbackScreen.tsx`, and by the regression tests. They extract existing behavior; they do not define a separate guided-training state machine.
 
-1. `stop-1` must be cleared before `mirror-1`.
-2. A complete sequence passes with score 100 and no feedback.
-3. Each missed checkpoint costs 20 points and reports its checkpoint ID.
-4. Retry starts with no cleared checkpoints while preserving the selected pedal input mode.
-5. Keyboard pedal mode uses the same checkpoint/result contract and does not require camera or Firebase state.
+1. Missed checkpoint IDs are active checkpoints not present in the cleared list. Production does not currently enforce checkpoint ordering.
+2. Each missed checkpoint costs 20 points in `store.ts`.
+3. Missed `stop` and `safety-check` checkpoints produce existing KAIZEN feedback. Missed `mirror` checkpoints currently produce no missed-checkpoint feedback. This surprising behavior is preserved and is a follow-up candidate, not fixed here.
+4. Final score is the existing `100 - KAIZEN penalties - floor(deviationPenalty)`, clamped at zero.
+5. Keyboard pedal mode does not alter checkpoint or scoring calculations.
 
-This is a testability seam, not a new lesson or a scoring-rule change. The production runtime remains the source of behavior and is not rewritten by Issue #31.
+This is a testability seam, not a new lesson or a scoring-rule change. The production runtime calls the same helpers tested by Issue #31.

--- a/docs/product/GUIDED_TRAINING_CONTRACT.md
+++ b/docs/product/GUIDED_TRAINING_CONTRACT.md
@@ -5,7 +5,7 @@ Issue #31 uses the existing `left-turn` lesson as the smallest deterministic gui
 ## Existing runtime slice
 
 - Course path: `src/lib/course.ts`, `left-turn`.
-- Checkpoints: `stop-1` and `mirror-1`, from `src/components/simulation/MissionController.tsx`.
+- Checkpoints: the `left-turn` entry from `src/lib/missionCheckpoints.ts`, re-exported by `src/components/simulation/MissionController.tsx`.
 - Goal: the existing left-turn goal in `MISSION_GOALS`.
 - Runtime scoring and checkpoint penalties are implemented in `src/lib/store.ts`.
 - Retry remains the existing `FeedbackScreen.tsx` flow: clear replay data, set mission state to `briefing`, and show `driving`.
@@ -14,7 +14,7 @@ Issue #31 uses the existing `left-turn` lesson as the smallest deterministic gui
 
 The helpers in `src/lib/guidedTrainingContract.ts` are imported by production `store.ts` and `FeedbackScreen.tsx`, and by the regression tests. They extract existing behavior; they do not define a separate guided-training state machine.
 
-1. Missed checkpoint IDs are active checkpoints not present in the cleared list. Production does not currently enforce checkpoint ordering.
+1. Missed checkpoint IDs are active checkpoints not present in the cleared list. Production does not currently enforce checkpoint ordering. Tests consume the same `MISSION_CHECKPOINTS["left-turn"]` definition as production.
 2. Each missed checkpoint costs 20 points in `store.ts`.
 3. Missed `stop` and `safety-check` checkpoints produce existing KAIZEN feedback. Missed `mirror` checkpoints currently produce no missed-checkpoint feedback. This surprising behavior is preserved and is a follow-up candidate, not fixed here.
 4. Final score is the existing `100 - KAIZEN penalties - floor(deviationPenalty)`, clamped at zero.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -11,6 +11,7 @@ const eslintConfig = defineConfig([
     ".next/**",
     "out/**",
     "build/**",
+    ".test-dist/**",
     "next-env.d.ts",
   ]),
   {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "start": "next start",
     "lint": "eslint",
     "type-check": "tsc --noEmit",
+    "test:guided": "tsc --project tsconfig.tests.json && node --test .test-dist/tests/guided-training-regression.test.js",
     "smoke": "start-server-and-test start http-get://127.0.0.1:3000 smoke:check",
     "smoke:check": "node -e \"\""
   },

--- a/src/components/simulation/MissionController.tsx
+++ b/src/components/simulation/MissionController.tsx
@@ -1,5 +1,7 @@
-import { LessonId } from "@/lib/store";
 import { Vector3 } from "three";
+
+export { MISSION_CHECKPOINTS } from "@/lib/missionCheckpoints";
+export type { Checkpoint, CheckpointType } from "@/lib/missionCheckpoints";
 
 export function MissionController() {
   // Logic is currently handled in Car.tsx due to access requirements
@@ -62,53 +64,6 @@ export const MISSION_GOALS: Record<
     size: [10, 5, 5],
     rotation: 0,
   },
-};
-
-// Checkpoints (Stop Signs, Mirrors)
-export type CheckpointType = 'stop' | 'mirror' | 'speed-limit' | 'safety-check';
-
-export interface Checkpoint {
-    id: string;
-    type: CheckpointType;
-    position: [number, number, number];
-    radius: number;
-    visual?: "traffic-light";
-    orientation?: "z" | "x";
-    // For stop signs:
-    minDuration?: number; // How long to stop
-    // For mirrors:
-    targetYaw?: number; // Expected look direction (radians)
-    yawTolerance?: number;
-    // ✅ Added: label used for feedback display
-    label?: string;
-}
-
-export const MISSION_CHECKPOINTS: Partial<Record<LessonId, Checkpoint[]>> = {
-    'left-turn': [
-        // Stop line before intersection
-        { id: 'stop-1', type: 'stop', position: [0, 0, -25], radius: 4, minDuration: 1000, label: '一時停止' },
-        // Curve Mirror check (Look Right/Forward-Right to check traffic)
-        { id: 'mirror-1', type: 'mirror', position: [0, 0, -28], radius: 6, targetYaw: -0.5, yawTolerance: 0.5, label: '安全確認' }
-    ],
-    'right-turn': [
-        { id: 'stop-1', type: 'stop', position: [0, 0, -25], radius: 4, label: '一時停止' },
-        // Mirror on Left Corner. Look Left.
-        { id: 'mirror-1', type: 'mirror', position: [0, 0, -28], radius: 6, targetYaw: 0.5, yawTolerance: 0.5, label: '安全確認' }
-    ],
-    "traffic-light": [
-        // Stop at the signal before entering (straight-ahead only)
-        { id: "signal-1", type: "stop", position: [0, 0, -18], radius: 4, minDuration: 1200, visual: "traffic-light", orientation: "z", label: '赤信号停止' },
-    ],
-    // ✅ Added: checkpoint for the crosswalk level
-    "crosswalk": [
-        // Stop just before the crosswalk
-        { id: 'cw-stop-1', type: 'stop', position: [0, 0, -25], radius: 5, minDuration: 1000, label: '横断歩道前停止' }
-    ],
-    // ✅ Added: level 8 checkpoint
-    "railroad-crossing": [
-        // Stop just before the railroad crossing
-        { id: 'rr-stop-1', type: 'stop', position: [0, 0, -50], radius: 5, minDuration: 2000, label: '踏切前一時停止' }
-    ]
 };
 
 export function checkMissionGoal(lesson: string, position: Vector3) {

--- a/src/components/ui/FeedbackScreen.tsx
+++ b/src/components/ui/FeedbackScreen.tsx
@@ -3,6 +3,7 @@ import { Scene } from "../simulation/Scene"; // Re-use scene for replay
 import { Suspense, useEffect, useRef } from "react";
 import {addDoc, collection } from 'firebase/firestore';
 import { db } from '@/lib/firebase';
+import { calculateFinalScore, getRetryTransition } from '@/lib/guidedTrainingContract';
 
 // User-facing strings, bilingual (ja/en).
 const STRINGS = {
@@ -76,9 +77,7 @@ export function FeedbackScreen() {
     try {
         const tt = STRINGS[useDrivingStore.getState().language];
         const kaizenLogs = state.feedbackLogs.filter((l: FeedbackEvent) => l.type === 'KAIZEN');
-        const kaizenPenalty = kaizenLogs.reduce((acc: number, l: FeedbackEvent) => acc + (typeof l.meta?.penalty === 'number' ? l.meta.penalty : 5), 0);
-        const totalPenalty = kaizenPenalty + Math.floor(state.deviationPenalty || 0);
-        const score = Math.max(0, 100 - totalPenalty);
+        const score = calculateFinalScore(state.feedbackLogs, state.deviationPenalty);
 
         // Clear Time Calculation
         const diff = state.missionEndTime - state.missionStartTime;
@@ -109,8 +108,9 @@ export function FeedbackScreen() {
   const handleRetry = () => {
     setIsReplaying(false);
     clearReplayData();
-    setMissionState('briefing');
-    setScreen('driving');
+    const retryTransition = getRetryTransition();
+    setMissionState(retryTransition.missionState);
+    setScreen(retryTransition.screen);
   };
 
   const handleHome = () => {
@@ -261,10 +261,10 @@ export function FeedbackScreen() {
                     <div className="text-xs text-slate-500 mb-1">Score</div>
                     <div className="text-3xl font-bold text-blue-400">
                         {(() => {
-                            const kaizenPenalty = kaizenLogs.reduce((acc, l) => acc + (typeof l.meta?.penalty === 'number' ? l.meta.penalty : 5), 0);
-                            const deviationPenalty = useDrivingStore.getState().deviationPenalty || 0;
-                            const totalPenalty = kaizenPenalty + Math.floor(deviationPenalty);
-                            return Math.max(0, 100 - totalPenalty);
+                            return calculateFinalScore(
+                              feedbackLogs,
+                              useDrivingStore.getState().deviationPenalty,
+                            );
                         })()}
                         <span className="text-sm text-slate-500">/100</span>
                     </div>

--- a/src/lib/guidedTrainingContract.ts
+++ b/src/lib/guidedTrainingContract.ts
@@ -1,0 +1,66 @@
+/**
+ * Deterministic contract for the existing left-turn guided-training slice.
+ *
+ * Runtime checkpoint registration and scoring remain in the existing store and
+ * simulation components. This small, dependency-free seam makes the contract
+ * testable without importing React, Three.js, Firebase, or MediaPipe.
+ */
+export const LEFT_TURN_CHECKPOINTS = ["stop-1", "mirror-1"] as const;
+
+export type LeftTurnCheckpoint = (typeof LEFT_TURN_CHECKPOINTS)[number];
+export type PedalInputMode = "camera" | "keyboard";
+
+export interface GuidedTrainingRun {
+  pedalInputMode: PedalInputMode;
+  clearedCheckpointIds: LeftTurnCheckpoint[];
+}
+
+export interface GuidedTrainingResult {
+  passed: boolean;
+  score: number;
+  missedCheckpointIds: LeftTurnCheckpoint[];
+  feedback: string[];
+}
+
+export function createGuidedTrainingRun(
+  pedalInputMode: PedalInputMode = "camera",
+): GuidedTrainingRun {
+  return { pedalInputMode, clearedCheckpointIds: [] };
+}
+
+export function clearCheckpoint(
+  run: GuidedTrainingRun,
+  checkpointId: LeftTurnCheckpoint,
+): GuidedTrainingRun {
+  const nextExpected = LEFT_TURN_CHECKPOINTS[run.clearedCheckpointIds.length];
+  if (checkpointId !== nextExpected) return run;
+
+  return {
+    ...run,
+    clearedCheckpointIds: [...run.clearedCheckpointIds, checkpointId],
+  };
+}
+
+export function evaluateGuidedTrainingRun(
+  run: GuidedTrainingRun,
+): GuidedTrainingResult {
+  const missedCheckpointIds = LEFT_TURN_CHECKPOINTS.filter(
+    (checkpointId) => !run.clearedCheckpointIds.includes(checkpointId),
+  );
+  const penalty = missedCheckpointIds.length * 20;
+
+  return {
+    passed: missedCheckpointIds.length === 0,
+    score: Math.max(0, 100 - penalty),
+    missedCheckpointIds: [...missedCheckpointIds],
+    feedback: missedCheckpointIds.map(
+      (checkpointId) => `Missed checkpoint: ${checkpointId}`,
+    ),
+  };
+}
+
+export function resetGuidedTrainingRun(
+  run: GuidedTrainingRun,
+): GuidedTrainingRun {
+  return createGuidedTrainingRun(run.pedalInputMode);
+}

--- a/src/lib/guidedTrainingContract.ts
+++ b/src/lib/guidedTrainingContract.ts
@@ -1,66 +1,67 @@
 /**
- * Deterministic contract for the existing left-turn guided-training slice.
- *
- * Runtime checkpoint registration and scoring remain in the existing store and
- * simulation components. This small, dependency-free seam makes the contract
- * testable without importing React, Three.js, Firebase, or MediaPipe.
+ * Small pure helpers extracted from the existing mission/result flow.
+ * Production imports these helpers from store.ts and FeedbackScreen.tsx;
+ * this module does not define a separate guided-training state machine.
  */
-export const LEFT_TURN_CHECKPOINTS = ["stop-1", "mirror-1"] as const;
-
-export type LeftTurnCheckpoint = (typeof LEFT_TURN_CHECKPOINTS)[number];
-export type PedalInputMode = "camera" | "keyboard";
-
-export interface GuidedTrainingRun {
-  pedalInputMode: PedalInputMode;
-  clearedCheckpointIds: LeftTurnCheckpoint[];
+export interface MissableCheckpoint {
+  id: string;
+  type: "stop" | "speed-limit" | "mirror" | "safety-check";
+  label?: string;
 }
 
-export interface GuidedTrainingResult {
-  passed: boolean;
-  score: number;
-  missedCheckpointIds: LeftTurnCheckpoint[];
-  feedback: string[];
+export interface FeedbackLike {
+  type: string;
+  meta?: Record<string, unknown>;
 }
 
-export function createGuidedTrainingRun(
-  pedalInputMode: PedalInputMode = "camera",
-): GuidedTrainingRun {
-  return { pedalInputMode, clearedCheckpointIds: [] };
+export function getMissedCheckpointIds(
+  activeCheckpoints: readonly Pick<MissableCheckpoint, "id">[],
+  clearedCheckpointIds: readonly string[],
+): string[] {
+  return activeCheckpoints
+    .filter((checkpoint) => !clearedCheckpointIds.includes(checkpoint.id))
+    .map((checkpoint) => checkpoint.id);
 }
 
-export function clearCheckpoint(
-  run: GuidedTrainingRun,
-  checkpointId: LeftTurnCheckpoint,
-): GuidedTrainingRun {
-  const nextExpected = LEFT_TURN_CHECKPOINTS[run.clearedCheckpointIds.length];
-  if (checkpointId !== nextExpected) return run;
-
-  return {
-    ...run,
-    clearedCheckpointIds: [...run.clearedCheckpointIds, checkpointId],
-  };
+export function getMissedCheckpointPenalty(missedCheckpointIds: readonly string[]): number {
+  return missedCheckpointIds.length * 20;
 }
 
-export function evaluateGuidedTrainingRun(
-  run: GuidedTrainingRun,
-): GuidedTrainingResult {
-  const missedCheckpointIds = LEFT_TURN_CHECKPOINTS.filter(
-    (checkpointId) => !run.clearedCheckpointIds.includes(checkpointId),
-  );
-  const penalty = missedCheckpointIds.length * 20;
-
-  return {
-    passed: missedCheckpointIds.length === 0,
-    score: Math.max(0, 100 - penalty),
-    missedCheckpointIds: [...missedCheckpointIds],
-    feedback: missedCheckpointIds.map(
-      (checkpointId) => `Missed checkpoint: ${checkpointId}`,
-    ),
-  };
+export function getMissedCheckpointFeedback(
+  checkpoint: MissableCheckpoint,
+  language: "ja" | "en",
+): string {
+  if (checkpoint.type === "stop") {
+    return language === "en"
+      ? "You ignored a required stop"
+      : `${checkpoint.label || "一時停止"}を無視しました`;
+  }
+  if (checkpoint.type === "safety-check") {
+    return language === "en"
+      ? "You skipped a safety check"
+      : `${checkpoint.label || "安全確認"}を行いませんでした`;
+  }
+  // Current production behavior intentionally has no missed feedback for mirrors.
+  return "";
 }
 
-export function resetGuidedTrainingRun(
-  run: GuidedTrainingRun,
-): GuidedTrainingRun {
-  return createGuidedTrainingRun(run.pedalInputMode);
+export function calculateFinalScore(
+  feedbackLogs: readonly FeedbackLike[],
+  deviationPenalty: number,
+): number {
+  const kaizenPenalty = feedbackLogs
+    .filter((log) => log.type === "KAIZEN")
+    .reduce(
+      (total, log) =>
+        total + (typeof log.meta?.penalty === "number" ? log.meta.penalty : 5),
+      0,
+    );
+  return Math.max(0, 100 - kaizenPenalty - Math.floor(deviationPenalty || 0));
+}
+
+export function getRetryTransition(): {
+  missionState: "briefing";
+  screen: "driving";
+} {
+  return { missionState: "briefing", screen: "driving" };
 }

--- a/src/lib/missionCheckpoints.ts
+++ b/src/lib/missionCheckpoints.ts
@@ -1,0 +1,38 @@
+/**
+ * Dependency-light mission checkpoint definitions shared by runtime code and
+ * deterministic regression tests.
+ */
+export type CheckpointType = "stop" | "mirror" | "speed-limit" | "safety-check";
+
+export interface Checkpoint {
+  id: string;
+  type: CheckpointType;
+  position: [number, number, number];
+  radius: number;
+  visual?: "traffic-light";
+  orientation?: "z" | "x";
+  minDuration?: number;
+  targetYaw?: number;
+  yawTolerance?: number;
+  label?: string;
+}
+
+export const MISSION_CHECKPOINTS: Partial<Record<string, Checkpoint[]>> = {
+  "left-turn": [
+    { id: "stop-1", type: "stop", position: [0, 0, -25], radius: 4, minDuration: 1000, label: "一時停止" },
+    { id: "mirror-1", type: "mirror", position: [0, 0, -28], radius: 6, targetYaw: -0.5, yawTolerance: 0.5, label: "安全確認" },
+  ],
+  "right-turn": [
+    { id: "stop-1", type: "stop", position: [0, 0, -25], radius: 4, label: "一時停止" },
+    { id: "mirror-1", type: "mirror", position: [0, 0, -28], radius: 6, targetYaw: 0.5, yawTolerance: 0.5, label: "安全確認" },
+  ],
+  "traffic-light": [
+    { id: "signal-1", type: "stop", position: [0, 0, -18], radius: 4, minDuration: 1200, visual: "traffic-light", orientation: "z", label: "赤信号停止" },
+  ],
+  "crosswalk": [
+    { id: "cw-stop-1", type: "stop", position: [0, 0, -25], radius: 5, minDuration: 1000, label: "横断歩道前停止" },
+  ],
+  "railroad-crossing": [
+    { id: "rr-stop-1", type: "stop", position: [0, 0, -50], radius: 5, minDuration: 2000, label: "踏切前一時停止" },
+  ],
+};

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -3,6 +3,11 @@ import { FootCalibration, PedalState } from "./footPedalRecognition";
 import * as THREE from "three";
 import { User } from "firebase/auth";
 import { MISSION_CHECKPOINTS } from "@/components/simulation/MissionController";
+import {
+  getMissedCheckpointFeedback,
+  getMissedCheckpointIds,
+  getMissedCheckpointPenalty,
+} from "./guidedTrainingContract";
 
 export interface ReplayFrame {
   timestamp: number;
@@ -350,8 +355,12 @@ export const useDrivingStore = create<DrivingState>((set) => ({
 
     // ▼▼▼ Added: detect uncleared checkpoints (dynamically registered ones) ▼▼▼
     // Find entries that are in activeCheckpoints but not in clearedCheckpointIds
-    const missedCheckpoints = st.activeCheckpoints.filter(
-        cp => !st.clearedCheckpointIds.includes(cp.id)
+    const missedCheckpointIds = getMissedCheckpointIds(
+      st.activeCheckpoints,
+      st.clearedCheckpointIds,
+    );
+    const missedCheckpoints = st.activeCheckpoints.filter((cp) =>
+      missedCheckpointIds.includes(cp.id),
     );
     // ▲▲▲ End of addition ▲▲▲
 
@@ -383,12 +392,7 @@ export const useDrivingStore = create<DrivingState>((set) => ({
       // English mode uses type-based wording; Japanese mode keeps the specific
       // checkpoint label (which is the JA-mode display text).
       missedCheckpoints.forEach(cp => {
-        let msg = "";
-        if (cp.type === 'stop') {
-          msg = lang === 'en' ? 'You ignored a required stop' : `${cp.label || '一時停止'}を無視しました`;
-        } else if (cp.type === 'safety-check') {
-          msg = lang === 'en' ? 'You skipped a safety check' : `${cp.label || '安全確認'}を行いませんでした`;
-        }
+        const msg = getMissedCheckpointFeedback(cp, lang);
 
         if (msg) {
             newLogs.push({
@@ -401,7 +405,7 @@ export const useDrivingStore = create<DrivingState>((set) => ({
       // ▲▲▲ End of addition ▲▲▲
 
       // Add a penalty based on the number of uncleared checkpoints (e.g. 20 points each)
-      const missedPenalty = missedCheckpoints.length * 20;
+      const missedPenalty = getMissedCheckpointPenalty(missedCheckpointIds);
 
       return {
         deviationPenalty: s.deviationPenalty + deviationPenalty + missedPenalty,

--- a/tests/guided-training-regression.test.ts
+++ b/tests/guided-training-regression.test.ts
@@ -1,0 +1,66 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  clearCheckpoint,
+  createGuidedTrainingRun,
+  evaluateGuidedTrainingRun,
+  resetGuidedTrainingRun,
+} from "../src/lib/guidedTrainingContract.js";
+
+test("successful left-turn run clears checkpoints in order", () => {
+  let run = createGuidedTrainingRun();
+  run = clearCheckpoint(run, "stop-1");
+  run = clearCheckpoint(run, "mirror-1");
+
+  assert.deepEqual(evaluateGuidedTrainingRun(run), {
+    passed: true,
+    score: 100,
+    missedCheckpointIds: [],
+    feedback: [],
+  });
+});
+
+test("missed checkpoint produces the expected penalty and feedback", () => {
+  let run = createGuidedTrainingRun();
+  run = clearCheckpoint(run, "stop-1");
+  const result = evaluateGuidedTrainingRun(run);
+
+  assert.equal(result.passed, false);
+  assert.equal(result.score, 80);
+  assert.deepEqual(result.missedCheckpointIds, ["mirror-1"]);
+  assert.deepEqual(result.feedback, ["Missed checkpoint: mirror-1"]);
+});
+
+test("retry reset clears temporary checkpoint and score state", () => {
+  let run = createGuidedTrainingRun();
+  run = clearCheckpoint(run, "stop-1");
+  run = clearCheckpoint(run, "mirror-1");
+  assert.equal(evaluateGuidedTrainingRun(run).score, 100);
+
+  const retry = resetGuidedTrainingRun(run);
+  assert.deepEqual(retry, {
+    pedalInputMode: "camera",
+    clearedCheckpointIds: [],
+  });
+  assert.equal(evaluateGuidedTrainingRun(retry).score, 60);
+});
+
+test("keyboard pedal fallback completes the same slice without camera state", () => {
+  let run = createGuidedTrainingRun("keyboard");
+  run = clearCheckpoint(run, "stop-1");
+  run = clearCheckpoint(run, "mirror-1");
+
+  assert.equal(run.pedalInputMode, "keyboard");
+  assert.equal(evaluateGuidedTrainingRun(run).score, 100);
+});
+
+test("out-of-order checkpoint events do not bypass the required sequence", () => {
+  let run = createGuidedTrainingRun();
+  run = clearCheckpoint(run, "mirror-1");
+
+  assert.deepEqual(run.clearedCheckpointIds, []);
+  assert.deepEqual(evaluateGuidedTrainingRun(run).missedCheckpointIds, [
+    "stop-1",
+    "mirror-1",
+  ]);
+});

--- a/tests/guided-training-regression.test.ts
+++ b/tests/guided-training-regression.test.ts
@@ -1,66 +1,52 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 import {
-  clearCheckpoint,
-  createGuidedTrainingRun,
-  evaluateGuidedTrainingRun,
-  resetGuidedTrainingRun,
+  calculateFinalScore,
+  getMissedCheckpointFeedback,
+  getMissedCheckpointIds,
+  getMissedCheckpointPenalty,
+  getRetryTransition,
 } from "../src/lib/guidedTrainingContract.js";
 
-test("successful left-turn run clears checkpoints in order", () => {
-  let run = createGuidedTrainingRun();
-  run = clearCheckpoint(run, "stop-1");
-  run = clearCheckpoint(run, "mirror-1");
+const leftTurnCheckpoints = [
+  { id: "stop-1", type: "stop" as const, label: "一時停止" },
+  { id: "mirror-1", type: "mirror" as const, label: "安全確認" },
+];
 
-  assert.deepEqual(evaluateGuidedTrainingRun(run), {
-    passed: true,
-    score: 100,
-    missedCheckpointIds: [],
-    feedback: [],
+test("successful left-turn result has no missed-checkpoint penalty", () => {
+  const missed = getMissedCheckpointIds(leftTurnCheckpoints, ["stop-1", "mirror-1"]);
+
+  assert.deepEqual(missed, []);
+  assert.equal(getMissedCheckpointPenalty(missed), 0);
+  assert.equal(calculateFinalScore([], getMissedCheckpointPenalty(missed)), 100);
+});
+
+test("missed checkpoint follows current production semantics", () => {
+  const missed = getMissedCheckpointIds(leftTurnCheckpoints, ["stop-1"]);
+  const missedMirror = leftTurnCheckpoints.find((checkpoint) => checkpoint.id === missed[0]);
+
+  assert.deepEqual(missed, ["mirror-1"]);
+  assert.equal(getMissedCheckpointPenalty(missed), 20);
+  assert.equal(getMissedCheckpointFeedback(missedMirror!, "en"), "");
+  assert.equal(calculateFinalScore([], getMissedCheckpointPenalty(missed)), 80);
+});
+
+test("retry transition matches the production feedback flow", () => {
+  assert.deepEqual(getRetryTransition(), {
+    missionState: "briefing",
+    screen: "driving",
   });
 });
 
-test("missed checkpoint produces the expected penalty and feedback", () => {
-  let run = createGuidedTrainingRun();
-  run = clearCheckpoint(run, "stop-1");
-  const result = evaluateGuidedTrainingRun(run);
+test("keyboard pedal mode does not alter the scoring/checkpoint contract", () => {
+  const missed = getMissedCheckpointIds(leftTurnCheckpoints, ["stop-1", "mirror-1"]);
+  const penalty = getMissedCheckpointPenalty(missed);
 
-  assert.equal(result.passed, false);
-  assert.equal(result.score, 80);
-  assert.deepEqual(result.missedCheckpointIds, ["mirror-1"]);
-  assert.deepEqual(result.feedback, ["Missed checkpoint: mirror-1"]);
-});
+  // Production scoring does not read pedalInputMode; camera and keyboard runs
+  // therefore use the same checkpoint and score helpers.
+  const cameraScore = calculateFinalScore([], penalty);
+  const keyboardScore = calculateFinalScore([], penalty);
 
-test("retry reset clears temporary checkpoint and score state", () => {
-  let run = createGuidedTrainingRun();
-  run = clearCheckpoint(run, "stop-1");
-  run = clearCheckpoint(run, "mirror-1");
-  assert.equal(evaluateGuidedTrainingRun(run).score, 100);
-
-  const retry = resetGuidedTrainingRun(run);
-  assert.deepEqual(retry, {
-    pedalInputMode: "camera",
-    clearedCheckpointIds: [],
-  });
-  assert.equal(evaluateGuidedTrainingRun(retry).score, 60);
-});
-
-test("keyboard pedal fallback completes the same slice without camera state", () => {
-  let run = createGuidedTrainingRun("keyboard");
-  run = clearCheckpoint(run, "stop-1");
-  run = clearCheckpoint(run, "mirror-1");
-
-  assert.equal(run.pedalInputMode, "keyboard");
-  assert.equal(evaluateGuidedTrainingRun(run).score, 100);
-});
-
-test("out-of-order checkpoint events do not bypass the required sequence", () => {
-  let run = createGuidedTrainingRun();
-  run = clearCheckpoint(run, "mirror-1");
-
-  assert.deepEqual(run.clearedCheckpointIds, []);
-  assert.deepEqual(evaluateGuidedTrainingRun(run).missedCheckpointIds, [
-    "stop-1",
-    "mirror-1",
-  ]);
+  assert.deepEqual(missed, []);
+  assert.equal(keyboardScore, cameraScore);
 });

--- a/tests/guided-training-regression.test.ts
+++ b/tests/guided-training-regression.test.ts
@@ -7,14 +7,16 @@ import {
   getMissedCheckpointPenalty,
   getRetryTransition,
 } from "../src/lib/guidedTrainingContract.js";
+import { MISSION_CHECKPOINTS } from "../src/lib/missionCheckpoints.js";
 
-const leftTurnCheckpoints = [
-  { id: "stop-1", type: "stop" as const, label: "一時停止" },
-  { id: "mirror-1", type: "mirror" as const, label: "安全確認" },
-];
+const leftTurnCheckpoints = MISSION_CHECKPOINTS["left-turn"] ?? [];
+const stopCheckpoint = leftTurnCheckpoints[0];
+const mirrorCheckpoint = leftTurnCheckpoints[1];
+assert.ok(stopCheckpoint);
+assert.ok(mirrorCheckpoint);
 
 test("successful left-turn result has no missed-checkpoint penalty", () => {
-  const missed = getMissedCheckpointIds(leftTurnCheckpoints, ["stop-1", "mirror-1"]);
+  const missed = getMissedCheckpointIds(leftTurnCheckpoints, [stopCheckpoint.id, mirrorCheckpoint.id]);
 
   assert.deepEqual(missed, []);
   assert.equal(getMissedCheckpointPenalty(missed), 0);
@@ -22,10 +24,10 @@ test("successful left-turn result has no missed-checkpoint penalty", () => {
 });
 
 test("missed checkpoint follows current production semantics", () => {
-  const missed = getMissedCheckpointIds(leftTurnCheckpoints, ["stop-1"]);
-  const missedMirror = leftTurnCheckpoints.find((checkpoint) => checkpoint.id === missed[0]);
+  const missed = getMissedCheckpointIds(leftTurnCheckpoints, [stopCheckpoint.id]);
+  const missedMirror = leftTurnCheckpoints.find((checkpoint) => checkpoint.id === mirrorCheckpoint.id);
 
-  assert.deepEqual(missed, ["mirror-1"]);
+  assert.deepEqual(missed, [mirrorCheckpoint.id]);
   assert.equal(getMissedCheckpointPenalty(missed), 20);
   assert.equal(getMissedCheckpointFeedback(missedMirror!, "en"), "");
   assert.equal(calculateFinalScore([], getMissedCheckpointPenalty(missed)), 80);
@@ -39,7 +41,7 @@ test("retry transition matches the production feedback flow", () => {
 });
 
 test("keyboard pedal mode does not alter the scoring/checkpoint contract", () => {
-  const missed = getMissedCheckpointIds(leftTurnCheckpoints, ["stop-1", "mirror-1"]);
+  const missed = getMissedCheckpointIds(leftTurnCheckpoints, [stopCheckpoint.id, mirrorCheckpoint.id]);
   const penalty = getMissedCheckpointPenalty(missed);
 
   // Production scoring does not read pedalInputMode; camera and keyboard runs

--- a/tsconfig.tests.json
+++ b/tsconfig.tests.json
@@ -1,0 +1,15 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": ".test-dist",
+    "rootDir": ".",
+    "noEmit": false,
+    "noEmitOnError": true
+  },
+  "include": [
+    "src/lib/guidedTrainingContract.ts",
+    "tests/guided-training-regression.test.ts"
+  ]
+}


### PR DESCRIPTION
## Summary

- Bind GO-01 regression coverage to the production left-turn checkpoint definition.
- Enforce `npm run test:guided` in the existing quality job for every PR and push.
- Preserve runtime behavior; no checkpoint ordering, mirror feedback, or scoring rules changed.

## Shared production definitions

- `src/lib/missionCheckpoints.ts` owns `MISSION_CHECKPOINTS`, including the left-turn slice.
- `src/components/simulation/MissionController.tsx` re-exports the shared definition for existing runtime consumers.
- `tests/guided-training-regression.test.ts` imports `MISSION_CHECKPOINTS["left-turn"]` directly; checkpoint IDs are not duplicated in the test.
- `src/lib/store.ts` and the existing RoadProps runtime path continue consuming the same definition.
- `src/lib/store.ts` and `src/components/ui/FeedbackScreen.tsx` consume the pure scoring/checkpoint helpers covered by the tests.

Runtime behavior changed: **No**.

## Issue

Closes #31

## Regression coverage

- [x] Successful left-turn result with all production-defined checkpoints cleared.
- [x] Missed checkpoint using current production semantics, including the existing penalty and mirror-feedback behavior.
- [x] Retry transition matches the existing FeedbackScreen flow.
- [x] Keyboard pedal mode does not alter the scoring/checkpoint contract.
- [x] Webcam, Firebase, network, time, and randomness are not required.

## Documentation

- Updated `docs/product/GUIDED_TRAINING_CONTRACT.md` with the shared checkpoint-definition location.
- Updated `docs/logs/2026-08/ISSUE-31-guided-training-regression.md` with the extraction and CI enforcement.

## Verification

- [x] `npm ci` — pass (Node 22.16.0 environment; package recommends Node 24+)
- [x] `npm run test:guided` — 4 passed, 0 failed
- [x] `npm run lint` — 0 errors; 5 existing React hook dependency warnings remain
- [x] `npm run type-check` — pass
- [x] `git diff --check` — pass
- [x] CI quality job includes `npm run test:guided` after lint and before type-check

## Risks / follow-up

The existing mirror missed-feedback behavior remains unchanged and is documented as a follow-up candidate. Browser, camera, and Firebase integration behavior are not exercised by these deterministic unit tests.

## Reviewer checklist

- [x] Scope remains limited to Issue #31.
- [x] Tests consume the production checkpoint definition.
- [x] `test:guided` is enforced by CI.
- [x] No invented checkpoint ordering, pass semantics, or mirror feedback claims remain.
- [x] Runtime behavior is unchanged.
- [x] Self-review completed.
- [ ] Merge — maintainers only after review and approval.