### PR TITLE
fix(vision): stabilize camera onboarding and calibration recovery

### DIFF
--- a/docs/logs/2026-08/ISSUE-32-camera-onboarding-recovery.md
+++ b/docs/logs/2026-08/ISSUE-32-camera-onboarding-recovery.md
@@ -1,0 +1,54 @@
+# Issue #32 — Camera onboarding and calibration recovery
+
+## Date
+
+2026-08-15 JST
+
+## Current failure modes found
+
+- `VisionController` calls `getUserMedia` after MediaPipe models are ready. Permission denial and other camera errors were displayed with a Retry button, but there was no direct keyboard-pedal action in the error panel.
+- MediaPipe setup failures were logged to the console without a user-facing recovery state.
+- Foot calibration reported missing landmarks through the debug/status text and could remain in `waiting_for_brake`; the tutorial's keyboard link was the only recovery path.
+- Keyboard pedal processing already returned early in `VisionController`, while hand-based steering continued. `KeyboardControls` already provided W/S and arrow-key input.
+- The tutorial did not identify the active pedal mode on its final pre-driving screen.
+
+## Implemented recovery paths
+
+- Added `src/lib/onboardingRecovery.ts` with dependency-free camera failure classification and keyboard fallback state helpers.
+- Added a direct `Use keyboard pedals` action to the camera error panel. It clears the calibration requirement, persists keyboard pedal mode, and preserves the optional tutorial continuation callback.
+- Added a `Retry calibration` action while calibration is waiting and a continuation action for keyboard mode.
+- Camera mode selection resets calibration state so returning from keyboard mode starts a fresh calibration attempt.
+- Added explicit Camera pedal / Keyboard pedal text on the final tutorial screen.
+- MediaPipe setup errors now enter the same user-facing recovery panel instead of only being logged.
+
+## Technical decisions
+
+- No new MediaPipe model, steering algorithm, or browser permission automation was added.
+- Keyboard fallback intentionally changes only pedal authority; camera hand steering remains active when the camera/hand pipeline is available.
+- Existing `KeyboardControls` remains the input implementation; the new action only makes its activation and calibration bypass explicit.
+
+## Tests
+
+`npm run test:guided` now covers the existing guided regression suite plus deterministic onboarding recovery checks:
+
+- permission errors classify as denied;
+- initialization errors classify as retryable errors;
+- keyboard fallback clears calibration requirements and selects keyboard pedals.
+
+## Manual verification
+
+Automated state and UI-path checks were completed locally. Real camera permission prompts, camera hardware, and mobile-sized viewport interaction were not available in this environment, so desktop camera allow/deny and mobile layout remain manual follow-up checks.
+
+## Verification
+
+- `npm ci`
+- `npm run test:guided`
+- `npm run lint`
+- `npm run type-check`
+- `git diff --check`
+
+## Remaining risks
+
+- Browser permission UI and device-specific camera errors differ by platform.
+- Full MediaPipe initialization and camera/hand tracking still need manual validation on supported desktop and mobile-sized viewports.
+- Existing lint hook-dependency warnings remain outside this Issue's scope.

--- a/docs/logs/2026-08/ISSUE-32-camera-onboarding-recovery.md
+++ b/docs/logs/2026-08/ISSUE-32-camera-onboarding-recovery.md
@@ -22,7 +22,7 @@
 - Added explicit Camera pedal / Keyboard pedal text on the final tutorial screen.
 - MediaPipe setup errors now enter the user-facing recovery panel with distinct copy and a vision-specific Retry action instead of only being logged.
 - Recovery copy is selected from the app language and overlapping camera/status panels are hidden while recovery is active.
-- Onboarding and driving are blocked behind a landscape gate for portrait viewports below 1024px; the gate renders no underlying training controls until landscape.
+- Onboarding and driving are blocked behind a hydration-safe landscape gate for portrait viewports at or below 1024px; the gate renders a neutral full-screen state until measurement, then renders no underlying training controls until landscape.
 - Recovery buttons use an equal-width vertical stack that fits narrow viewports.
 
 ## Technical decisions

--- a/docs/logs/2026-08/ISSUE-32-camera-onboarding-recovery.md
+++ b/docs/logs/2026-08/ISSUE-32-camera-onboarding-recovery.md
@@ -15,11 +15,12 @@
 ## Implemented recovery paths
 
 - Added `src/lib/onboardingRecovery.ts` with dependency-free camera failure classification and keyboard fallback state helpers.
-- Added a direct `Use keyboard pedals` action to the camera error panel. It clears the calibration requirement, persists keyboard pedal mode, and preserves the optional tutorial continuation callback.
+- Added a direct `Use keyboard pedals` action to the camera error panel. The panel is an interactive foreground layer; the background preview and status are pointer-transparent so tutorial navigation remains usable.
+- Camera errors retry `getUserMedia`; vision setup errors retry MediaPipe model initialization through the same bounded manual setup callback. Partially-created models are closed before retry.
 - Added a `Retry calibration` action while calibration is waiting and a continuation action for keyboard mode.
 - Camera mode selection resets calibration state so returning from keyboard mode starts a fresh calibration attempt.
 - Added explicit Camera pedal / Keyboard pedal text on the final tutorial screen.
-- MediaPipe setup errors now enter the same user-facing recovery panel instead of only being logged.
+- MediaPipe setup errors now enter the user-facing recovery panel with distinct copy and a vision-specific Retry action instead of only being logged.
 
 ## Technical decisions
 
@@ -33,11 +34,20 @@
 
 - permission errors classify as denied;
 - initialization errors classify as retryable errors;
+- vision setup failure selects the vision-setup retry path rather than camera-only retry;
 - keyboard fallback clears calibration requirements and selects keyboard pedals.
 
 ## Manual verification
 
 Automated state and UI-path checks were completed locally. Real camera permission prompts, camera hardware, and mobile-sized viewport interaction were not available in this environment, so desktop camera allow/deny and mobile layout remain manual follow-up checks.
+
+## Manual QA checklist for preview
+
+- Desktop camera allow → tutorial → successful calibration → Camera pedal visible → playable run.
+- Desktop camera deny → visible/clickable recovery → keyboard fallback → Arrow/A-D steering and W/S pedals → playable run.
+- Camera or vision initialization error → Retry runs the corresponding initialization path.
+- Calibration failure → Retry calibration or keyboard fallback → final tutorial step.
+- Mobile-sized viewport around 390×844 → recovery controls visible, no critical action off-screen, tutorial navigation usable.
 
 ## Verification
 

--- a/docs/logs/2026-08/ISSUE-32-camera-onboarding-recovery.md
+++ b/docs/logs/2026-08/ISSUE-32-camera-onboarding-recovery.md
@@ -21,6 +21,9 @@
 - Camera mode selection resets calibration state so returning from keyboard mode starts a fresh calibration attempt.
 - Added explicit Camera pedal / Keyboard pedal text on the final tutorial screen.
 - MediaPipe setup errors now enter the user-facing recovery panel with distinct copy and a vision-specific Retry action instead of only being logged.
+- Recovery copy is selected from the app language and overlapping camera/status panels are hidden while recovery is active.
+- Onboarding and driving are blocked behind a landscape gate for portrait viewports below 1024px; the gate renders no underlying training controls until landscape.
+- Recovery buttons use an equal-width vertical stack that fits narrow viewports.
 
 ## Technical decisions
 
@@ -36,6 +39,8 @@
 - initialization errors classify as retryable errors;
 - vision setup failure selects the vision-setup retry path rather than camera-only retry;
 - keyboard fallback clears calibration requirements and selects keyboard pedals.
+- Japanese and English recovery copy routes correctly by failure kind.
+- Portrait mobile/tablet dimensions require landscape while desktop and landscape dimensions remain unblocked.
 
 ## Manual verification
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "start": "next start",
     "lint": "eslint",
     "type-check": "tsc --noEmit",
-    "test:guided": "tsc --project tsconfig.tests.json && node --test .test-dist/tests/guided-training-regression.test.js",
+    "test:guided": "tsc --project tsconfig.tests.json && node --test .test-dist/tests/guided-training-regression.test.js .test-dist/tests/onboarding-recovery.test.js",
     "smoke": "start-server-and-test start http-get://127.0.0.1:3000 smoke:check",
     "smoke:check": "node -e \"\""
   },

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -44,3 +44,93 @@ a {
     color-scheme: dark;
   }
 }
+
+.vision-overlay {
+  top: 20px;
+  right: 20px;
+}
+
+.recovery-card {
+  width: min(320px, calc(100vw - 32px));
+  max-height: calc(100vh - 32px);
+  overflow-y: auto;
+  margin-bottom: 8px;
+  padding: 14px 16px;
+  border-radius: 10px;
+  box-sizing: border-box;
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+.recovery-title {
+  margin-bottom: 6px;
+  font-size: 14px;
+  font-weight: 700;
+}
+
+.recovery-message {
+  margin-bottom: 10px;
+}
+
+.recovery-settings-hint {
+  margin-bottom: 12px;
+  color: #fecaca;
+  font-size: 12px;
+}
+
+.recovery-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.recovery-button {
+  width: 100%;
+  min-height: 38px;
+  padding: 8px 12px;
+  border: none;
+  border-radius: 7px;
+  cursor: pointer;
+  font-size: 13px;
+  font-weight: 700;
+}
+
+@media (max-width: 600px), (max-height: 500px) {
+  .vision-overlay {
+    top: 12px;
+    right: 12px;
+  }
+
+  .recovery-card {
+    width: min(280px, calc(100vw - 24px));
+    max-height: calc(100vh - 24px);
+    padding: 10px 12px;
+    border-radius: 8px;
+    font-size: 11px;
+  }
+
+  .recovery-title {
+    margin-bottom: 4px;
+    font-size: 13px;
+  }
+
+  .recovery-message {
+    margin-bottom: 7px;
+  }
+
+  .recovery-settings-hint {
+    margin-bottom: 8px;
+    font-size: 10px;
+  }
+
+  .recovery-actions {
+    gap: 6px;
+  }
+
+  .recovery-button {
+    min-height: 35px;
+    padding: 6px 10px;
+    border-radius: 6px;
+    font-size: 12px;
+  }
+}

--- a/src/components/ClientApp.tsx
+++ b/src/components/ClientApp.tsx
@@ -13,6 +13,7 @@ import { HistoryScreen } from '@/components/ui/HistoryScreen';
 import { auth } from '@/lib/firebase';
 import { TutorialScreen } from '@/components/ui/TutorialScreen';
 import { LanguageScreen } from '@/components/ui/LanguageScreen';
+import { OrientationGate } from '@/components/ui/OrientationGate';
 
 const VisionController = dynamic(() => import('@/components/vision/VisionController'), { ssr: false });
 const Scene = dynamic(() => import('@/components/simulation/Scene').then(mod => mod.Scene), { ssr: false });
@@ -267,8 +268,9 @@ export default function ClientApp() {
           {screen === 'auth' && <AuthScreen />}
           {screen === 'history' && <HistoryScreen />}
 
-          {screen === 'tutorial' && <TutorialScreen />}
+          {screen === 'tutorial' && <OrientationGate><TutorialScreen /></OrientationGate>}
           {screen === 'driving' && (
+              <OrientationGate>
               <>
                 <VisionController isPaused={isPaused} />
                 <MissionOverlay />
@@ -296,6 +298,7 @@ export default function ClientApp() {
                     </Suspense>
                 </div>
               </>
+              </OrientationGate>
           )}
 
           {screen === 'feedback' && <FeedbackScreen />}

--- a/src/components/ui/OrientationGate.tsx
+++ b/src/components/ui/OrientationGate.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { ReactNode, useEffect, useState } from "react";
+import { useDrivingStore } from "@/lib/store";
+import { shouldRequireLandscape } from "@/lib/onboardingRecovery";
+
+const COPY = {
+  ja: { title: "横向きでご利用ください", body: "スマートフォンまたはタブレットを横向きにして続けてください。", hint: "↻ 端末を回転" },
+  en: { title: "Please rotate your device", body: "Turn your phone or tablet to landscape to continue.", hint: "↻ Rotate device" },
+} as const;
+
+export function OrientationGate({ children }: { children: ReactNode }) {
+  const language = useDrivingStore((state) => state.language);
+  const [blocked, setBlocked] = useState(() =>
+    typeof window !== "undefined" && shouldRequireLandscape(window.innerWidth, window.innerHeight),
+  );
+
+  useEffect(() => {
+    const update = () => setBlocked(shouldRequireLandscape(window.innerWidth, window.innerHeight));
+    update();
+    window.addEventListener("resize", update);
+    window.addEventListener("orientationchange", update);
+    return () => {
+      window.removeEventListener("resize", update);
+      window.removeEventListener("orientationchange", update);
+    };
+  }, []);
+
+  if (!blocked) return <>{children}</>;
+
+  const copy = COPY[language];
+  return (
+    <div className="fixed inset-0 z-[5000] flex items-center justify-center bg-slate-950 px-6 text-center text-white">
+      <div className="w-full max-w-sm rounded-2xl border border-slate-700 bg-slate-900 p-8 shadow-2xl">
+        <div className="mb-4 text-6xl" aria-hidden="true">↻</div>
+        <h1 className="mb-3 text-2xl font-bold text-cyan-300">{copy.title}</h1>
+        <p className="text-base leading-relaxed text-slate-300">{copy.body}</p>
+        <p className="mt-6 font-semibold text-cyan-200">{copy.hint}</p>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ui/OrientationGate.tsx
+++ b/src/components/ui/OrientationGate.tsx
@@ -11,9 +11,9 @@ const COPY = {
 
 export function OrientationGate({ children }: { children: ReactNode }) {
   const language = useDrivingStore((state) => state.language);
-  const [blocked, setBlocked] = useState(() =>
-    typeof window !== "undefined" && shouldRequireLandscape(window.innerWidth, window.innerHeight),
-  );
+  // Keep server render and first client render identical. Viewport detection
+  // happens only after hydration, before the training UI is revealed.
+  const [blocked, setBlocked] = useState<boolean | null>(null);
 
   useEffect(() => {
     const update = () => setBlocked(shouldRequireLandscape(window.innerWidth, window.innerHeight));
@@ -25,6 +25,10 @@ export function OrientationGate({ children }: { children: ReactNode }) {
       window.removeEventListener("orientationchange", update);
     };
   }, []);
+
+  if (blocked === null) {
+    return <div className="fixed inset-0 z-[5000] bg-slate-950" aria-busy="true" />;
+  }
 
   if (!blocked) return <>{children}</>;
 

--- a/src/components/ui/TutorialScreen.tsx
+++ b/src/components/ui/TutorialScreen.tsx
@@ -149,10 +149,10 @@ export function TutorialScreen() {
 
     // Start calibration once step 4 is reached
     useEffect(() => {
-        if (step === 4 && calibrationStage === 'idle') {
+        if (step === 4 && calibrationStage === 'idle' && pedalInputMode === 'camera') {
             startCalibration();
         }
-    }, [step, calibrationStage, startCalibration]);
+    }, [step, calibrationStage, pedalInputMode, startCalibration]);
 
     const nextStep = () => {
         if (step < 5) setStep((prev) => (prev + 1) as 1 | 2 | 3 | 4 | 5);
@@ -166,7 +166,7 @@ export function TutorialScreen() {
         <div className="relative w-full h-full bg-slate-900 text-white overflow-hidden flex flex-col items-center justify-center">
 
             {/* Always show VisionController in the background (so the camera feed can be checked) */}
-            <div className="absolute top-0 left-0 w-full h-full opacity-50 z-0 pointer-events-none">
+            <div className="absolute top-0 left-0 w-full h-full">
                 <VisionController
                     isPaused={false}
                     onKeyboardFallback={() => {

--- a/src/components/ui/TutorialScreen.tsx
+++ b/src/components/ui/TutorialScreen.tsx
@@ -51,6 +51,10 @@ const STRINGS = {
         statusMeasuring: '足の位置を計測中...',
         statusDone: 'キャリブレーション完了',
         calibratedMessage: '設定完了！足を前へ出すとブレーキ、手前でアクセルです。',
+        cameraPedalMode: 'カメラペダル',
+        keyboardPedalMode: 'キーボードペダル（W: アクセル / S: ブレーキ）',
+        retryCalibration: 'キャリブレーションをやり直す',
+        continueWithKeyboard: 'キーボード操作で続ける',
         keyboardModeActive: 'キーボードモードで操作します（W: アクセル / S: ブレーキ）',
         backToCamera: 'カメラで足を認識する操作に戻す',
         switchToKeyboard: '足の検出がうまくいかない場合は、キーボードで操作する（W / S）',
@@ -108,6 +112,10 @@ const STRINGS = {
         statusMeasuring: 'Measuring foot position...',
         statusDone: 'Calibration complete',
         calibratedMessage: 'All set! Move your foot forward to brake and back to accelerate.',
+        cameraPedalMode: 'Camera pedal',
+        keyboardPedalMode: 'Keyboard pedal (W: accelerator / S: brake)',
+        retryCalibration: 'Retry calibration',
+        continueWithKeyboard: 'Continue with keyboard pedals',
         keyboardModeActive: 'Using keyboard controls (W: accelerator / S: brake)',
         backToCamera: 'Switch back to camera-based foot control',
         switchToKeyboard: "If foot detection isn't working well, control with the keyboard (W / S)",
@@ -132,6 +140,7 @@ export function TutorialScreen() {
     const steeringAngle = useDrivingStore(state => state.steeringAngle);
     const pedalInputMode = useDrivingStore(state => state.pedalInputMode);
     const setPedalInputMode = useDrivingStore(state => state.setPedalInputMode);
+    const activateKeyboardPedalFallback = useDrivingStore(state => state.activateKeyboardPedalFallback);
     const language = useDrivingStore((state) => state.language);
     const t = STRINGS[language];
 
@@ -158,7 +167,12 @@ export function TutorialScreen() {
 
             {/* Always show VisionController in the background (so the camera feed can be checked) */}
             <div className="absolute top-0 left-0 w-full h-full opacity-50 z-0 pointer-events-none">
-                <VisionController isPaused={false} />
+                <VisionController
+                    isPaused={false}
+                    onKeyboardFallback={() => {
+                        nextStep();
+                    }}
+                />
             </div>
 
             {/* Overlay Video Removed - now a dedicated step */}
@@ -305,14 +319,30 @@ export function TutorialScreen() {
                                 >
                                     {t.backToCamera}
                                 </button>
+                                <button
+                                    onClick={nextStep}
+                                    className="ml-4 text-xs text-cyan-200 underline hover:text-white transition-colors"
+                                >
+                                    {t.continueWithKeyboard}
+                                </button>
                             </div>
                         ) : (
-                            <button
-                                onClick={() => { setPedalInputMode('keyboard'); nextStep(); }}
-                                className="mt-4 text-sm text-slate-400 underline hover:text-white transition-colors"
-                            >
-                                {t.switchToKeyboard}
-                            </button>
+                            <>
+                                <button
+                                    onClick={() => { activateKeyboardPedalFallback(); nextStep(); }}
+                                    className="mt-4 text-sm text-slate-400 underline hover:text-white transition-colors"
+                                >
+                                    {t.switchToKeyboard}
+                                </button>
+                                {calibrationStage === 'waiting_for_brake' && (
+                                    <button
+                                        onClick={startCalibration}
+                                        className="ml-4 mt-4 text-sm text-yellow-300 underline hover:text-white transition-colors"
+                                    >
+                                        {t.retryCalibration}
+                                    </button>
+                                )}
+                            </>
                         )}
                     </div>
                 )}
@@ -324,6 +354,9 @@ export function TutorialScreen() {
                          <p className="text-lg text-slate-300 mb-8">
                              {t.readyLine1}<br/>
                              {t.readyLine2}
+                         </p>
+                         <p className="text-cyan-300 font-semibold mb-8">
+                             {pedalInputMode === 'keyboard' ? t.keyboardPedalMode : t.cameraPedalMode}
                          </p>
 
                          <button

--- a/src/components/vision/VisionController.tsx
+++ b/src/components/vision/VisionController.tsx
@@ -5,7 +5,7 @@ import { FilesetResolver, FaceLandmarker, HandLandmarker, DrawingUtils, HandLand
 import { useDrivingStore } from "@/lib/store";
 import { processPedalRecognition, checkFootStability } from "@/lib/footPedalRecognition";
 import { PoseLandmarkFilterManager } from "@/lib/oneEuroFilter";
-import { classifyCameraFailure, getRecoveryRetryAction, RecoveryKind } from "@/lib/onboardingRecovery";
+import { classifyCameraFailure, getRecoveryCopy, getRecoveryRetryAction, RecoveryKind } from "@/lib/onboardingRecovery";
 
 // How often (ms) the per-frame status string is allowed to be written to the
 // store. The detection loop runs at display rate; the human-readable panel only
@@ -40,6 +40,7 @@ export default function VisionController({
   const setGaze = useDrivingStore((state) => state.setGaze); // Gaze action
   const setGear = useDrivingStore((state) => state.setGear);
   const activateKeyboardPedalFallback = useDrivingStore((state) => state.activateKeyboardPedalFallback);
+  const language = useDrivingStore((state) => state.language);
 
 
   // References
@@ -811,12 +812,7 @@ export default function VisionController({
   };
 
   const statusDisplay = getStatusDisplay();
-  const recoveryTitle = recoveryKind === "vision-error"
-    ? "⚙️ Vision setup unavailable"
-    : recoveryKind === "camera-denied"
-      ? "📷 Camera permission denied"
-      : "📷 Camera unavailable";
-  const retryLabel = recoveryKind === "vision-error" ? "Retry vision setup" : "Retry camera";
+  const recoveryCopy = getRecoveryCopy(recoveryKind, language);
 
   return (
     <div style={{
@@ -841,7 +837,7 @@ export default function VisionController({
             color: '#fff',
             padding: '14px 16px',
             borderRadius: '10px',
-            width: '280px',
+            width: 'min(320px, calc(100vw - 32px))',
             marginBottom: '8px',
             boxSizing: 'border-box',
             boxShadow: '0 4px 12px rgba(0,0,0,0.4)',
@@ -849,40 +845,48 @@ export default function VisionController({
             lineHeight: 1.5,
             pointerEvents: 'auto',
           }}>
-            <div style={{ fontWeight: 'bold', marginBottom: '6px', fontSize: '14px' }}>{recoveryTitle}</div>
-            <div style={{ marginBottom: '10px' }}>{cameraError}</div>
-            <button
-              onClick={retryRecovery}
-              disabled={isSettingUpVision}
-              style={{
-                padding: '6px 14px',
-                fontSize: '13px',
-                fontWeight: 'bold',
-                color: '#7f1d1d',
-                backgroundColor: '#fff',
-                border: 'none',
-                borderRadius: '6px',
-                cursor: 'pointer',
-              }}
-            >{isSettingUpVision ? 'Retrying...' : retryLabel}</button>
-            <button
-              onClick={activateKeyboardFallback}
-              style={{
-                marginLeft: '8px',
-                padding: '6px 10px',
-                fontSize: '13px',
-                fontWeight: 'bold',
-                color: '#164e63',
-                backgroundColor: '#a5f3fc',
-                border: 'none',
-                borderRadius: '6px',
-                cursor: 'pointer',
-              }}
-            >Use keyboard pedals</button>
+            <div style={{ fontWeight: 'bold', marginBottom: '6px', fontSize: '14px' }}>{recoveryCopy.title}</div>
+            <div style={{ marginBottom: '10px' }}>{recoveryCopy.message}</div>
+            {recoveryCopy.settingsHint && (
+              <div style={{ marginBottom: '12px', color: '#fecaca', fontSize: '12px' }}>{recoveryCopy.settingsHint}</div>
+            )}
+            <div style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
+              <button
+                onClick={retryRecovery}
+                disabled={isSettingUpVision}
+                style={{
+                  width: '100%',
+                  minHeight: '38px',
+                  padding: '8px 12px',
+                  fontSize: '13px',
+                  fontWeight: 'bold',
+                  color: '#7f1d1d',
+                  backgroundColor: '#fff',
+                  border: 'none',
+                  borderRadius: '7px',
+                  cursor: 'pointer',
+                }}
+              >{isSettingUpVision ? (language === 'ja' ? '再試行中...' : 'Retrying...') : recoveryCopy.retryLabel}</button>
+              <button
+                onClick={activateKeyboardFallback}
+                style={{
+                  width: '100%',
+                  minHeight: '38px',
+                  padding: '8px 12px',
+                  fontSize: '13px',
+                  fontWeight: 'bold',
+                  color: '#164e63',
+                  backgroundColor: '#a5f3fc',
+                  border: 'none',
+                  borderRadius: '7px',
+                  cursor: 'pointer',
+                }}
+              >{recoveryCopy.fallbackLabel}</button>
+            </div>
           </div>
         )}
 
-        <div style={{
+        {!cameraError && <div style={{
           position: "relative",
           width: "240px",
           height: "180px",
@@ -896,10 +900,10 @@ export default function VisionController({
                 backgroundColor: 'black', // This is visible when stopped
                 transform: 'scaleX(-1)'
             }} />
-        </div>
+        </div>}
 
         {/* Status display panel */}
-        <div style={{
+        {!cameraError && <div style={{
             backgroundColor: statusDisplay.bgColor,
             backdropFilter: 'blur(10px)',
             border: `2px solid ${statusDisplay.color}`,
@@ -927,7 +931,7 @@ export default function VisionController({
             }}>
                 {statusDisplay.message}
             </div>
-        </div>
+        </div>}
     </div>
   );
 }

--- a/src/components/vision/VisionController.tsx
+++ b/src/components/vision/VisionController.tsx
@@ -5,13 +5,20 @@ import { FilesetResolver, FaceLandmarker, HandLandmarker, DrawingUtils, HandLand
 import { useDrivingStore } from "@/lib/store";
 import { processPedalRecognition, checkFootStability } from "@/lib/footPedalRecognition";
 import { PoseLandmarkFilterManager } from "@/lib/oneEuroFilter";
+import { classifyCameraFailure } from "@/lib/onboardingRecovery";
 
 // How often (ms) the per-frame status string is allowed to be written to the
 // store. The detection loop runs at display rate; the human-readable panel only
 // needs to refresh a few times per second.
 const DEBUG_THROTTLE_MS = 150;
 
-export default function VisionController({ isPaused }: { isPaused: boolean }) {
+export default function VisionController({
+  isPaused,
+  onKeyboardFallback,
+}: {
+  isPaused: boolean;
+  onKeyboardFallback?: () => void;
+}) {
   const videoRef = useRef<HTMLVideoElement>(null);
   const canvasRef = useRef<HTMLCanvasElement>(null);
 
@@ -30,6 +37,7 @@ export default function VisionController({ isPaused }: { isPaused: boolean }) {
   const setCalibrationStage = useDrivingStore((state) => state.setCalibrationStage);
   const setGaze = useDrivingStore((state) => state.setGaze); // Gaze action
   const setGear = useDrivingStore((state) => state.setGear);
+  const activateKeyboardPedalFallback = useDrivingStore((state) => state.activateKeyboardPedalFallback);
 
 
   // References
@@ -112,6 +120,12 @@ export default function VisionController({ isPaused }: { isPaused: boolean }) {
     setDebugInfo("Camera Stopped (Paused)");
   }, [setDebugInfo]);
 
+  const activateKeyboardFallback = useCallback(() => {
+    activateKeyboardPedalFallback();
+    onKeyboardFallback?.();
+    setCameraError(null);
+  }, [activateKeyboardPedalFallback, onKeyboardFallback, setCameraError]);
+
   // Function to start the camera
   const startCamera = useCallback(async () => {
     try {
@@ -148,7 +162,7 @@ export default function VisionController({ isPaused }: { isPaused: boolean }) {
         setDebugInfo("Camera Started");
     } catch (e) {
         console.error("Camera Error:", e);
-        const denied = e instanceof DOMException && (e.name === "NotAllowedError" || e.name === "PermissionDeniedError");
+        const denied = classifyCameraFailure(e) === "denied";
         setCameraError(
             denied
                 ? "Camera access was denied. Allow it in your browser settings, or drive with the keyboard (use the arrow keys to steer)."
@@ -236,8 +250,10 @@ export default function VisionController({ isPaused }: { isPaused: boolean }) {
             poseLandmarkerRef.current = null;
             objectDetectorRef.current = null;
         }
-      } catch (error) {
+    } catch (error) {
         console.error(error);
+        setCameraError("Vision setup failed. Retry camera setup or use keyboard pedals to continue.");
+        setDebugInfo("Vision setup error: " + String(error));
       }
     }
     setupMediaPipe();
@@ -798,6 +814,20 @@ export default function VisionController({ isPaused }: { isPaused: boolean }) {
                 cursor: 'pointer',
               }}
             >Retry</button>
+            <button
+              onClick={activateKeyboardFallback}
+              style={{
+                marginLeft: '8px',
+                padding: '6px 10px',
+                fontSize: '13px',
+                fontWeight: 'bold',
+                color: '#164e63',
+                backgroundColor: '#a5f3fc',
+                border: 'none',
+                borderRadius: '6px',
+                cursor: 'pointer',
+              }}
+            >Use keyboard pedals</button>
           </div>
         )}
 

--- a/src/components/vision/VisionController.tsx
+++ b/src/components/vision/VisionController.tsx
@@ -815,10 +815,8 @@ export default function VisionController({
   const recoveryCopy = getRecoveryCopy(recoveryKind, language);
 
   return (
-    <div style={{
+    <div className="vision-overlay" style={{
         position: 'fixed',
-        top: '20px',
-        right: '20px',
         zIndex: 2000,
         display: 'flex',
         flexDirection: 'column',
@@ -831,55 +829,34 @@ export default function VisionController({
 
         {/* User guidance shown when the camera fails to start (retry + keyboard control fallback) */}
         {cameraError && (
-          <div style={{
+          <div className="recovery-card" style={{
             backgroundColor: 'rgba(127, 29, 29, 0.95)',
             border: '2px solid #f87171',
             color: '#fff',
-            padding: '14px 16px',
-            borderRadius: '10px',
-            width: 'min(320px, calc(100vw - 32px))',
-            marginBottom: '8px',
-            boxSizing: 'border-box',
             boxShadow: '0 4px 12px rgba(0,0,0,0.4)',
-            fontSize: '13px',
-            lineHeight: 1.5,
             pointerEvents: 'auto',
           }}>
-            <div style={{ fontWeight: 'bold', marginBottom: '6px', fontSize: '14px' }}>{recoveryCopy.title}</div>
-            <div style={{ marginBottom: '10px' }}>{recoveryCopy.message}</div>
+            <div className="recovery-title">{recoveryCopy.title}</div>
+            <div className="recovery-message">{recoveryCopy.message}</div>
             {recoveryCopy.settingsHint && (
-              <div style={{ marginBottom: '12px', color: '#fecaca', fontSize: '12px' }}>{recoveryCopy.settingsHint}</div>
+              <div className="recovery-settings-hint">{recoveryCopy.settingsHint}</div>
             )}
-            <div style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
+            <div className="recovery-actions">
               <button
                 onClick={retryRecovery}
                 disabled={isSettingUpVision}
+                className="recovery-button recovery-button-primary"
                 style={{
-                  width: '100%',
-                  minHeight: '38px',
-                  padding: '8px 12px',
-                  fontSize: '13px',
-                  fontWeight: 'bold',
                   color: '#7f1d1d',
                   backgroundColor: '#fff',
-                  border: 'none',
-                  borderRadius: '7px',
-                  cursor: 'pointer',
                 }}
               >{isSettingUpVision ? (language === 'ja' ? '再試行中...' : 'Retrying...') : recoveryCopy.retryLabel}</button>
               <button
                 onClick={activateKeyboardFallback}
+                className="recovery-button recovery-button-secondary"
                 style={{
-                  width: '100%',
-                  minHeight: '38px',
-                  padding: '8px 12px',
-                  fontSize: '13px',
-                  fontWeight: 'bold',
                   color: '#164e63',
                   backgroundColor: '#a5f3fc',
-                  border: 'none',
-                  borderRadius: '7px',
-                  cursor: 'pointer',
                 }}
               >{recoveryCopy.fallbackLabel}</button>
             </div>

--- a/src/components/vision/VisionController.tsx
+++ b/src/components/vision/VisionController.tsx
@@ -5,7 +5,7 @@ import { FilesetResolver, FaceLandmarker, HandLandmarker, DrawingUtils, HandLand
 import { useDrivingStore } from "@/lib/store";
 import { processPedalRecognition, checkFootStability } from "@/lib/footPedalRecognition";
 import { PoseLandmarkFilterManager } from "@/lib/oneEuroFilter";
-import { classifyCameraFailure } from "@/lib/onboardingRecovery";
+import { classifyCameraFailure, getRecoveryRetryAction, RecoveryKind } from "@/lib/onboardingRecovery";
 
 // How often (ms) the per-frame status string is allowed to be written to the
 // store. The detection loop runs at display rate; the human-readable panel only
@@ -25,6 +25,8 @@ export default function VisionController({
   // User-facing camera error (denied / unavailable / unsupported). When set, an
   // overlay explains the problem and offers a retry + keyboard-control fallback.
   const [cameraError, setCameraError] = useState<string | null>(null);
+  const [recoveryKind, setRecoveryKind] = useState<RecoveryKind>("camera-error");
+  const [isSettingUpVision, setIsSettingUpVision] = useState(false);
 
   // Store actions
   const setHeadRotation = useDrivingStore((state) => state.setHeadRotation);
@@ -68,6 +70,7 @@ export default function VisionController({
     new PoseLandmarkFilterManager(1.0, 0.004, 1.5)
   );
   const streamRef = useRef<MediaStream | null>(null); // Stream management
+  const isMountedRef = useRef(true);
   // Ref-indirection so startCamera's useCallback can invoke the loop without
   // capturing predictWebcam as a dependency (the function is declared below).
   const predictWebcamRef = useRef<() => void>(() => {});
@@ -137,6 +140,7 @@ export default function VisionController({
 
         // Browser without camera API support (e.g. insecure context / old browser).
         if (!navigator.mediaDevices?.getUserMedia) {
+            setRecoveryKind("camera-error");
             setCameraError("This browser does not support the camera. You can drive with the keyboard (use the arrow keys to steer).");
             setDebugInfo("Camera not supported");
             return;
@@ -163,6 +167,7 @@ export default function VisionController({
     } catch (e) {
         console.error("Camera Error:", e);
         const denied = classifyCameraFailure(e) === "denied";
+        setRecoveryKind(denied ? "camera-denied" : "camera-error");
         setCameraError(
             denied
                 ? "Camera access was denied. Allow it in your browser settings, or drive with the keyboard (use the arrow keys to steer)."
@@ -173,16 +178,31 @@ export default function VisionController({
   }, [setDebugInfo, setCameraError]); // Do not add predictWebcam to the dependencies (it loops)
 
   // Initialization (loading MediaPipe)
-  useEffect(() => {
-    let isMounted = true;
-    async function setupMediaPipe() {
+  const setupMediaPipe = useCallback(async () => {
+      setIsSettingUpVision(true);
+      setCameraError(null);
+      setDebugInfo("Loading AI Models...");
+
+      // Release partially-created resources before a manual retry.
+      faceLandmarkerRef.current?.close();
+      handLandmarkerRef.current?.close();
+      poseLandmarkerRef.current?.close();
+      objectDetectorRef.current?.close();
+      faceLandmarkerRef.current = null;
+      handLandmarkerRef.current = null;
+      poseLandmarkerRef.current = null;
+      objectDetectorRef.current = null;
+
+      let faceLandmarker: FaceLandmarker | null = null;
+      let handLandmarker: HandLandmarker | null = null;
+      let poseLandmarker: PoseLandmarker | null = null;
+      let objectDetector: ObjectDetector | null = null;
       try {
-        setDebugInfo("Loading AI Models...");
         const filesetResolver = await FilesetResolver.forVisionTasks(
           "https://cdn.jsdelivr.net/npm/@mediapipe/tasks-vision@0.10.3/wasm"
         );
 
-        const faceLandmarker = await FaceLandmarker.createFromOptions(filesetResolver, {
+        faceLandmarker = await FaceLandmarker.createFromOptions(filesetResolver, {
           baseOptions: {
             modelAssetPath: `https://storage.googleapis.com/mediapipe-models/face_landmarker/face_landmarker/float16/1/face_landmarker.task`,
             delegate: "GPU"
@@ -192,7 +212,7 @@ export default function VisionController({
           numFaces: 1
         });
 
-        const handLandmarker = await HandLandmarker.createFromOptions(filesetResolver, {
+        handLandmarker = await HandLandmarker.createFromOptions(filesetResolver, {
           baseOptions: {
             modelAssetPath: `https://storage.googleapis.com/mediapipe-models/hand_landmarker/hand_landmarker/float16/1/hand_landmarker.task`,
             delegate: "GPU"
@@ -204,7 +224,7 @@ export default function VisionController({
           minTrackingConfidence: 0.3
         });
 
-        poseLandmarkerRef.current = await PoseLandmarker.createFromOptions(filesetResolver, {
+        poseLandmarker = await PoseLandmarker.createFromOptions(filesetResolver, {
           baseOptions: {
             // 'full' over 'lite': markedly better on distant / low-contrast
             // bodies (e.g. dark clothing) at a moderate GPU cost. Swap to
@@ -221,7 +241,7 @@ export default function VisionController({
           minTrackingConfidence: 0.3
         });
 
-        objectDetectorRef.current = await ObjectDetector.createFromOptions(filesetResolver, {
+        objectDetector = await ObjectDetector.createFromOptions(filesetResolver, {
           baseOptions: {
             modelAssetPath: `https://storage.googleapis.com/mediapipe-models/object_detector/efficientdet_lite0/float16/1/efficientdet_lite0.tflite`,
             delegate: "GPU"
@@ -230,36 +250,59 @@ export default function VisionController({
           runningMode: "VIDEO"
         });
 
-        if (isMounted) {
-            faceLandmarkerRef.current = faceLandmarker;
-            handLandmarkerRef.current = handLandmarker;
-            setVisionReady(true);
-            setDebugInfo("Models Ready.");
-
-            // On first load completion, start the camera if not paused
-            if (!isPausedRef.current) {
-                startCamera();
-            }
-        } else {
-            // Unmounted while models were still loading (e.g. React StrictMode's
-            // double mount in development) — release everything we created.
-            faceLandmarker.close();
-            handLandmarker.close();
-            poseLandmarkerRef.current?.close();
-            objectDetectorRef.current?.close();
-            poseLandmarkerRef.current = null;
-            objectDetectorRef.current = null;
+        if (!isMountedRef.current) {
+          faceLandmarker.close();
+          handLandmarker.close();
+          poseLandmarker.close();
+          objectDetector.close();
+          return;
         }
-    } catch (error) {
+
+        faceLandmarkerRef.current = faceLandmarker;
+        handLandmarkerRef.current = handLandmarker;
+        poseLandmarkerRef.current = poseLandmarker;
+        objectDetectorRef.current = objectDetector;
+        setVisionReady(true);
+        setDebugInfo("Models Ready.");
+
+        // On first load or manual retry, start the camera if not paused.
+        if (!isPausedRef.current) {
+            await startCamera();
+        }
+      } catch (error) {
         console.error(error);
-        setCameraError("Vision setup failed. Retry camera setup or use keyboard pedals to continue.");
+        faceLandmarker?.close();
+        handLandmarker?.close();
+        poseLandmarker?.close();
+        objectDetector?.close();
+        faceLandmarkerRef.current = null;
+        handLandmarkerRef.current = null;
+        poseLandmarkerRef.current = null;
+        objectDetectorRef.current = null;
+        setVisionReady(false);
+        setRecoveryKind("vision-error");
+        setCameraError("Vision setup failed. Retry vision setup or use keyboard pedals to continue.");
         setDebugInfo("Vision setup error: " + String(error));
+      } finally {
+        setIsSettingUpVision(false);
       }
+  }, [setCameraError, setDebugInfo, setVisionReady, startCamera]);
+
+  const retryRecovery = useCallback(() => {
+    setCameraError(null);
+    if (getRecoveryRetryAction(recoveryKind) === "vision-retry") {
+      void setupMediaPipe();
+    } else {
+      void startCamera();
     }
-    setupMediaPipe();
+  }, [recoveryKind, setCameraError, setupMediaPipe, startCamera]);
+
+  useEffect(() => {
+    isMountedRef.current = true;
+    void setupMediaPipe();
 
     return () => {
-        isMounted = false;
+        isMountedRef.current = false;
         stopCamera(); // Make sure to stop on unmount
         // Release MediaPipe model resources to avoid leaking GPU/WASM contexts.
         faceLandmarkerRef.current?.close();
@@ -272,7 +315,7 @@ export default function VisionController({
         objectDetectorRef.current = null;
         drawingUtilsRef.current = null;
     };
-  }, []); // Run only once
+  }, [setupMediaPipe, stopCamera]);
 
   // Turn the camera on/off in response to changes in isPaused
   useEffect(() => {
@@ -319,7 +362,6 @@ export default function VisionController({
     // lastProcessingTimeRef.current = now;
 
     if (faceLandmarkerRef.current && handLandmarkerRef.current && video.readyState >= 2 && video.videoWidth > 0 && video.videoHeight > 0 && video.currentTime !== lastVideoTimeRef.current) {
-      // eslint-disable-next-line react-hooks/purity
         const startTimeMs = performance.now();
          
         const deltaTime = lastFrameTimeRef.current === 0 ? 16 : startTimeMs - lastFrameTimeRef.current;
@@ -769,6 +811,12 @@ export default function VisionController({
   };
 
   const statusDisplay = getStatusDisplay();
+  const recoveryTitle = recoveryKind === "vision-error"
+    ? "⚙️ Vision setup unavailable"
+    : recoveryKind === "camera-denied"
+      ? "📷 Camera permission denied"
+      : "📷 Camera unavailable";
+  const retryLabel = recoveryKind === "vision-error" ? "Retry vision setup" : "Retry camera";
 
   return (
     <div style={{
@@ -780,6 +828,7 @@ export default function VisionController({
         flexDirection: 'column',
         alignItems: 'flex-end',
         opacity: 0.9,
+        pointerEvents: 'none',
     }}>
         {/* The video tag is hidden and runs in the background */}
         <video ref={videoRef} style={{ display: 'none' }} autoPlay playsInline muted></video>
@@ -798,11 +847,13 @@ export default function VisionController({
             boxShadow: '0 4px 12px rgba(0,0,0,0.4)',
             fontSize: '13px',
             lineHeight: 1.5,
+            pointerEvents: 'auto',
           }}>
-            <div style={{ fontWeight: 'bold', marginBottom: '6px', fontSize: '14px' }}>📷 Camera unavailable</div>
+            <div style={{ fontWeight: 'bold', marginBottom: '6px', fontSize: '14px' }}>{recoveryTitle}</div>
             <div style={{ marginBottom: '10px' }}>{cameraError}</div>
             <button
-              onClick={() => { setCameraError(null); startCamera(); }}
+              onClick={retryRecovery}
+              disabled={isSettingUpVision}
               style={{
                 padding: '6px 14px',
                 fontSize: '13px',
@@ -813,7 +864,7 @@ export default function VisionController({
                 borderRadius: '6px',
                 cursor: 'pointer',
               }}
-            >Retry</button>
+            >{isSettingUpVision ? 'Retrying...' : retryLabel}</button>
             <button
               onClick={activateKeyboardFallback}
               style={{

--- a/src/lib/onboardingRecovery.ts
+++ b/src/lib/onboardingRecovery.ts
@@ -88,5 +88,5 @@ export function getRecoveryCopy(kind: RecoveryKind, language: RecoveryLanguage):
 }
 
 export function shouldRequireLandscape(width: number, height: number): boolean {
-  return width < 1024 && height > width;
+  return width <= 1024 && height > width;
 }

--- a/src/lib/onboardingRecovery.ts
+++ b/src/lib/onboardingRecovery.ts
@@ -1,10 +1,19 @@
 export type CameraFailureKind = "denied" | "error";
 export type RecoveryKind = "camera-denied" | "camera-error" | "vision-error";
+export type RecoveryLanguage = "ja" | "en";
 
 export interface KeyboardFallbackState {
   pedalInputMode: "keyboard";
   calibrationStage: "idle";
   footCalibration: null;
+}
+
+export interface RecoveryCopy {
+  title: string;
+  message: string;
+  retryLabel: string;
+  fallbackLabel: string;
+  settingsHint?: string;
 }
 
 export function classifyCameraFailure(error: unknown): CameraFailureKind {
@@ -24,4 +33,60 @@ export function getKeyboardFallbackState(): KeyboardFallbackState {
 
 export function getRecoveryRetryAction(kind: RecoveryKind): "camera-retry" | "vision-retry" {
   return kind === "vision-error" ? "vision-retry" : "camera-retry";
+}
+
+export function getRecoveryCopy(kind: RecoveryKind, language: RecoveryLanguage): RecoveryCopy {
+  if (language === "ja") {
+    if (kind === "camera-denied") {
+      return {
+        title: "📷 カメラの許可が必要です",
+        message: "カメラへのアクセスが拒否されました。ブラウザのサイト設定でカメラを許可してから再試行してください。",
+        retryLabel: "カメラを再試行",
+        fallbackLabel: "キーボード操作を使う",
+        settingsHint: "ブラウザがこのサイトをブロックした場合は、サイト設定のカメラ権限を変更してください。",
+      };
+    }
+    if (kind === "vision-error") {
+      return {
+        title: "⚙️ カメラ認識を開始できません",
+        message: "カメラ認識の準備に失敗しました。認識の準備を再試行するか、キーボード操作へ切り替えてください。",
+        retryLabel: "認識を再試行",
+        fallbackLabel: "キーボード操作を使う",
+      };
+    }
+    return {
+      title: "📷 カメラを起動できません",
+      message: "カメラの起動に失敗しました。カメラの接続を確認して再試行してください。",
+      retryLabel: "カメラを再試行",
+      fallbackLabel: "キーボード操作を使う",
+    };
+  }
+
+  if (kind === "camera-denied") {
+    return {
+      title: "📷 Camera permission required",
+      message: "Camera access was denied. Allow the camera in your browser site settings, then tap Retry.",
+      retryLabel: "Retry camera",
+      fallbackLabel: "Use keyboard controls",
+      settingsHint: "If the browser blocked this site, change camera permission in the site settings.",
+    };
+  }
+  if (kind === "vision-error") {
+    return {
+      title: "⚙️ Vision setup unavailable",
+      message: "Camera recognition setup failed. Retry vision setup or continue with keyboard controls.",
+      retryLabel: "Retry vision setup",
+      fallbackLabel: "Use keyboard controls",
+    };
+  }
+  return {
+    title: "📷 Camera unavailable",
+    message: "The camera could not be started. Check the camera connection and try again.",
+    retryLabel: "Retry camera",
+    fallbackLabel: "Use keyboard controls",
+  };
+}
+
+export function shouldRequireLandscape(width: number, height: number): boolean {
+  return width < 1024 && height > width;
 }

--- a/src/lib/onboardingRecovery.ts
+++ b/src/lib/onboardingRecovery.ts
@@ -1,0 +1,22 @@
+export type CameraFailureKind = "denied" | "error";
+
+export interface KeyboardFallbackState {
+  pedalInputMode: "keyboard";
+  calibrationStage: "idle";
+  footCalibration: null;
+}
+
+export function classifyCameraFailure(error: unknown): CameraFailureKind {
+  if (error instanceof DOMException && (error.name === "NotAllowedError" || error.name === "PermissionDeniedError")) {
+    return "denied";
+  }
+  return "error";
+}
+
+export function getKeyboardFallbackState(): KeyboardFallbackState {
+  return {
+    pedalInputMode: "keyboard",
+    calibrationStage: "idle",
+    footCalibration: null,
+  };
+}

--- a/src/lib/onboardingRecovery.ts
+++ b/src/lib/onboardingRecovery.ts
@@ -1,4 +1,5 @@
 export type CameraFailureKind = "denied" | "error";
+export type RecoveryKind = "camera-denied" | "camera-error" | "vision-error";
 
 export interface KeyboardFallbackState {
   pedalInputMode: "keyboard";
@@ -19,4 +20,8 @@ export function getKeyboardFallbackState(): KeyboardFallbackState {
     calibrationStage: "idle",
     footCalibration: null,
   };
+}
+
+export function getRecoveryRetryAction(kind: RecoveryKind): "camera-retry" | "vision-retry" {
+  return kind === "vision-error" ? "vision-retry" : "camera-retry";
 }

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -8,6 +8,7 @@ import {
   getMissedCheckpointIds,
   getMissedCheckpointPenalty,
 } from "./guidedTrainingContract";
+import { getKeyboardFallbackState } from "./onboardingRecovery";
 
 export interface ReplayFrame {
   timestamp: number;
@@ -133,6 +134,7 @@ export interface DrivingState {
   // when legs/feet can't be tracked reliably. See docs/superpowers/plans/0004.
   pedalInputMode: "camera" | "keyboard";
   setPedalInputMode: (mode: "camera" | "keyboard") => void;
+  activateKeyboardPedalFallback: () => void;
 
   // Mission scoring/time
   missionStartTime: number;
@@ -425,7 +427,16 @@ export const useDrivingStore = create<DrivingState>((set) => ({
   setCalibrationStage: (stage) => set({ calibrationStage: stage }),
   setPedalInputMode: (mode) => {
     if (typeof window !== "undefined") localStorage.setItem("pedalInputMode", mode);
-    set({ pedalInputMode: mode });
+    if (mode === "camera") {
+      set({ pedalInputMode: mode, calibrationStage: "idle", footCalibration: null });
+      return;
+    }
+    set(getKeyboardFallbackState());
+  },
+  activateKeyboardPedalFallback: () => {
+    const fallbackState = getKeyboardFallbackState();
+    if (typeof window !== "undefined") localStorage.setItem("pedalInputMode", fallbackState.pedalInputMode);
+    set(fallbackState);
   },
   startCalibration: () =>
     set({

--- a/tests/onboarding-recovery.test.ts
+++ b/tests/onboarding-recovery.test.ts
@@ -37,6 +37,8 @@ test("recovery copy follows the selected language and failure kind", () => {
 
 test("portrait mobile and tablet viewports require landscape", () => {
   assert.equal(shouldRequireLandscape(390, 844), true);
+  assert.equal(shouldRequireLandscape(1024, 1366), true);
   assert.equal(shouldRequireLandscape(844, 390), false);
+  assert.equal(shouldRequireLandscape(1366, 1024), false);
   assert.equal(shouldRequireLandscape(1440, 900), false);
 });

--- a/tests/onboarding-recovery.test.ts
+++ b/tests/onboarding-recovery.test.ts
@@ -3,7 +3,9 @@ import { test } from "node:test";
 import {
   classifyCameraFailure,
   getKeyboardFallbackState,
+  getRecoveryCopy,
   getRecoveryRetryAction,
+  shouldRequireLandscape,
 } from "../src/lib/onboardingRecovery.js";
 
 test("camera permission failure is classified as denied", () => {
@@ -25,4 +27,16 @@ test("keyboard fallback clears calibration requirements while preserving the mod
     calibrationStage: "idle",
     footCalibration: null,
   });
+});
+
+test("recovery copy follows the selected language and failure kind", () => {
+  assert.match(getRecoveryCopy("camera-denied", "ja").message, /ブラウザ/);
+  assert.match(getRecoveryCopy("camera-denied", "en").settingsHint ?? "", /site settings/);
+  assert.equal(getRecoveryCopy("vision-error", "ja").retryLabel, "認識を再試行");
+});
+
+test("portrait mobile and tablet viewports require landscape", () => {
+  assert.equal(shouldRequireLandscape(390, 844), true);
+  assert.equal(shouldRequireLandscape(844, 390), false);
+  assert.equal(shouldRequireLandscape(1440, 900), false);
 });

--- a/tests/onboarding-recovery.test.ts
+++ b/tests/onboarding-recovery.test.ts
@@ -1,0 +1,19 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { classifyCameraFailure, getKeyboardFallbackState } from "../src/lib/onboardingRecovery.js";
+
+test("camera permission failure is classified as denied", () => {
+  assert.equal(classifyCameraFailure(new DOMException("blocked", "NotAllowedError")), "denied");
+});
+
+test("camera initialization failure is classified as a retryable error", () => {
+  assert.equal(classifyCameraFailure(new Error("device unavailable")), "error");
+});
+
+test("keyboard fallback clears calibration requirements while preserving the mode", () => {
+  assert.deepEqual(getKeyboardFallbackState(), {
+    pedalInputMode: "keyboard",
+    calibrationStage: "idle",
+    footCalibration: null,
+  });
+});

--- a/tests/onboarding-recovery.test.ts
+++ b/tests/onboarding-recovery.test.ts
@@ -1,6 +1,10 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
-import { classifyCameraFailure, getKeyboardFallbackState } from "../src/lib/onboardingRecovery.js";
+import {
+  classifyCameraFailure,
+  getKeyboardFallbackState,
+  getRecoveryRetryAction,
+} from "../src/lib/onboardingRecovery.js";
 
 test("camera permission failure is classified as denied", () => {
   assert.equal(classifyCameraFailure(new DOMException("blocked", "NotAllowedError")), "denied");
@@ -8,6 +12,11 @@ test("camera permission failure is classified as denied", () => {
 
 test("camera initialization failure is classified as a retryable error", () => {
   assert.equal(classifyCameraFailure(new Error("device unavailable")), "error");
+});
+
+test("vision setup failure retries vision setup rather than camera-only startup", () => {
+  assert.equal(getRecoveryRetryAction("vision-error"), "vision-retry");
+  assert.equal(getRecoveryRetryAction("camera-error"), "camera-retry");
 });
 
 test("keyboard fallback clears calibration requirements while preserving the mode", () => {

--- a/tsconfig.tests.json
+++ b/tsconfig.tests.json
@@ -10,6 +10,8 @@
   },
   "include": [
     "src/lib/guidedTrainingContract.ts",
-    "tests/guided-training-regression.test.ts"
+    "src/lib/onboardingRecovery.ts",
+    "tests/guided-training-regression.test.ts",
+    "tests/onboarding-recovery.test.ts"
   ]
 }


### PR DESCRIPTION
## Summary

Polish Issue #32 onboarding/recovery UX after manual QA while preserving existing camera, keyboard, steering, and calibration behavior.

## Changes

- Recovery panel is a compact foreground card with equal-width, vertically stacked CTAs that fit narrow screens.
- Camera permission denial now explains that browser site settings must be changed before Retry can work; no fake settings-opening behavior is provided.
- Camera initialization and vision/MediaPipe setup failures retain distinct copy and retry paths.
- Recovery copy is localized for Japanese and English, including titles, messages, Retry, fallback, and browser-settings guidance.
- Camera preview/status are pointer-transparent and the redundant status panel is hidden while recovery is visible.
- Added `OrientationGate` to tutorial and driving screens: portrait viewports below 1024px show a JA/EN rotate-device blocker and do not render the interactive flow underneath.
- Added lightweight responsive sizing and manual QA checklist for 390x844 and landscape mobile/tablet viewports.
- Keyboard fallback wording does not imply camera steering when camera access is unavailable; existing pedal and steering behavior is unchanged.

## Related Issue

Closes #32

## Acceptance Criteria

- [x] Recovery Retry and keyboard fallback actions are aligned, equal-width, and interactive.
- [x] Denied permission explains browser settings and does not claim the app can re-enable permission.
- [x] Camera and vision setup failures retain correct retry paths.
- [x] Recovery copy follows the selected JA/EN language.
- [x] Redundant status/debug panel is suppressed during recovery.
- [x] Portrait mobile/tablet onboarding and training are blocked until landscape.
- [x] Keyboard fallback remains usable without calibration.
- [x] No MediaPipe model, steering, scoring, analytics, or curriculum changes.

## Verification

- [x] `npm ci` — pass (Node 22.16.0 environment; package recommends Node 24+)
- [x] `npm run test:guided` — 10 passed, 0 failed
- [x] `npm run lint` — 0 errors; 4 existing React hook dependency warnings
- [x] `npm run type-check`
- [x] `git diff --check`
- [x] GitHub Actions quality and Ubuntu/macOS/Windows build-smoke — PASS on final HEAD
- [ ] Real camera/permission/mobile viewport manual verification — unavailable in this environment

## Manual QA checklist for preview

- [ ] Desktop camera denied: recovery visible; Retry and fallback aligned; browser-settings guidance visible; keyboard fallback works.
- [ ] Desktop camera allowed: tutorial/calibration flow works; Camera pedal mode is visible before driving.
- [ ] Retry: camera error reruns camera startup; vision error reruns vision setup.
- [ ] Calibration failure: Retry calibration and keyboard fallback are available; keyboard mode reaches final tutorial step.
- [ ] Mobile portrait around 390x844: rotate blocker appears and unusable controls are not exposed.
- [ ] Mobile/tablet landscape: onboarding remains usable without clipping or panel overlap.
- [ ] Language: Japanese and English recovery copy match the selected language.

## Risks

Real camera permission UI, device-specific MediaPipe startup, and mobile viewport interaction require manual validation. Existing lint warnings remain outside this Issue's scope.

## Documentation Updated

- `docs/logs/2026-08/ISSUE-32-camera-onboarding-recovery.md`

## Reviewer Checklist

- [x] Scope matches Issue
- [x] No unrelated changes
- [x] Existing behavior is not unnecessarily rewritten
- [x] Tests are appropriate
- [ ] User-facing behavior verified on a real camera
- [x] Documentation updated
- [x] Work log updated
- [ ] Merge — maintainers only after review and approval
