### PR TITLE
feat(research): add public-safe test-session instrumentation

### DIFF
--- a/docs/logs/2026-08/ISSUE-30-camera-consent-session-instrumentation.md
+++ b/docs/logs/2026-08/ISSUE-30-camera-consent-session-instrumentation.md
@@ -1,0 +1,24 @@
+# Issue #30 — Camera consent and student-test session instrumentation
+
+## Selected slice
+
+The existing guest flow was kept: lesson/tutorial entry, explicit camera consent, camera or keyboard fallback, mission state transitions, retry, feedback, and an optional JSON summary export.
+
+## Consent and privacy boundary
+
+`VisionController` is not mounted until explicit consent. “Continue without camera” starts a keyboard session and does not mount MediaPipe or request `getUserMedia`. The session schema contains derived, bounded events only; it excludes raw media, landmark data, identity, account IDs, network identifiers, and free text.
+
+## Technical decisions and testability seams
+
+- `src/lib/testSession.ts` is the dependency-free typed session state/event seam used by production Zustand actions and pure tests.
+- Session state is in memory. Export is an explicit user-visible JSON download; there is no Firebase event upload or indefinite localStorage event log.
+- Camera permission and initialization outcomes are recorded at the existing `VisionController` transitions. Lesson start/completion/failure and retry are recorded at existing store/feedback transitions.
+- The session ID is random and non-identifying; the production generator prefers `crypto.randomUUID()`.
+
+## Verification
+
+Recorded after implementation: `npm ci`, `npm run test:guided`, `npm run lint`, `npm run type-check`, and `git diff --check`.
+
+## Remaining risks
+
+Browser permission behavior and external MediaPipe/model availability remain environment-dependent. Existing replay support may display a separately managed video URL; the new test-session export never includes it. A future privacy review should decide whether that legacy replay path should be removed or constrained independently.

--- a/docs/product/PRIVACY_AND_TEST_SESSIONS.md
+++ b/docs/product/PRIVACY_AND_TEST_SESSIONS.md
@@ -1,0 +1,19 @@
+# Camera consent and test-session data
+
+DrivingSupport asks for explicit consent before mounting the camera/vision runtime. A guest can continue with keyboard pedals without granting camera access.
+
+## Data boundary
+
+The MVP processes camera input for driving-practice recognition. It does not add raw camera frames, recorded video, screenshots, MediaPipe landmark arrays/geometries, participant names, email addresses, Firebase UIDs, IP addresses, device fingerprints, or free-text notes to a test session. This document describes the product behavior implemented for the usability-test slice; it is not a legal privacy policy.
+
+The active session is held in memory. There is no remote analytics upload and no indefinite local-storage session log. A participant or operator can explicitly export a JSON summary from the feedback screen.
+
+## Session summary
+
+Each test session receives a non-identifying random session ID. It is not derived from an account or device and is not used for cross-session tracking. The summary contains the schema version, session ID, start/end timestamps, consent state, bounded camera-permission outcome, selected input mode, lesson ID, completion state, retry count, bounded failure categories, and ordered derived events.
+
+Events are limited to: consent accepted, camera permission granted/denied, camera or vision initialization failure, input mode selected, lesson started/completed/failed, retry started, and session completed. Events contain only the schema version, session ID, relative timestamp, lesson/input mode where applicable, and a bounded failure category.
+
+## Limitations
+
+The event summary is intended to support a small external usability test, not to provide an analytics platform or prove driving-safety effectiveness. Camera behavior still depends on browser permissions, device capabilities, and MediaPipe availability. DrivingSupport remains supplementary practice and does not replace licensed instruction or real-road practice.

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "start": "next start",
     "lint": "eslint",
     "type-check": "tsc --noEmit",
-    "test:guided": "tsc --project tsconfig.tests.json && node --test .test-dist/tests/guided-training-regression.test.js .test-dist/tests/onboarding-recovery.test.js",
+    "test:guided": "tsc --project tsconfig.tests.json && node --test .test-dist/tests/guided-training-regression.test.js .test-dist/tests/onboarding-recovery.test.js .test-dist/tests/test-session.test.js",
     "smoke": "start-server-and-test start http-get://127.0.0.1:3000 smoke:check",
     "smoke:check": "node -e \"\""
   },

--- a/src/components/ClientApp.tsx
+++ b/src/components/ClientApp.tsx
@@ -14,6 +14,7 @@ import { auth } from '@/lib/firebase';
 import { TutorialScreen } from '@/components/ui/TutorialScreen';
 import { LanguageScreen } from '@/components/ui/LanguageScreen';
 import { OrientationGate } from '@/components/ui/OrientationGate';
+import { CameraConsent } from '@/components/ui/CameraConsent';
 
 const VisionController = dynamic(() => import('@/components/vision/VisionController'), { ssr: false });
 const Scene = dynamic(() => import('@/components/simulation/Scene').then(mod => mod.Scene), { ssr: false });
@@ -197,6 +198,9 @@ export default function ClientApp() {
   const setMisssionState = useDrivingStore(state => state.setMissionState);
   const language = useDrivingStore(state => state.language);
   const t = STRINGS[language];
+  const testSession = useDrivingStore(state => state.testSession);
+  const cameraProcessingAllowed = useDrivingStore(state => state.cameraProcessingAllowed);
+  const startTestSession = useDrivingStore(state => state.startTestSession);
 
   useDrivingFeedback(); // Activate Feedback Logic
 
@@ -271,8 +275,8 @@ export default function ClientApp() {
           {screen === 'tutorial' && <OrientationGate><TutorialScreen /></OrientationGate>}
           {screen === 'driving' && (
               <OrientationGate>
-              <>
-                <VisionController isPaused={isPaused} />
+              {!testSession ? <CameraConsent language={language} onChoose={startTestSession} /> : <>
+                {cameraProcessingAllowed && <VisionController isPaused={isPaused} />}
                 <MissionOverlay />
                 <KeyboardControls />
                 <Dashboard />
@@ -297,7 +301,7 @@ export default function ClientApp() {
                         <Scene />
                     </Suspense>
                 </div>
-              </>
+              </>}
               </OrientationGate>
           )}
 

--- a/src/components/ui/CameraConsent.tsx
+++ b/src/components/ui/CameraConsent.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+type Props = { language: "ja" | "en"; onChoose: (cameraProcessingAllowed: boolean) => void };
+
+export function CameraConsent({ language, onChoose }: Props) {
+  const en = language === "en";
+  return (
+    <div className="relative z-20 w-full max-w-xl rounded-xl border border-slate-600 bg-slate-800 p-6 text-white shadow-2xl">
+      <h2 className="mb-4 text-2xl font-bold text-blue-400">{en ? "Before practice" : "練習を始める前に"}</h2>
+      <p className="mb-4 text-slate-200">
+        {en ? "The camera can be used for driving-practice motion recognition." : "カメラは運転練習の動作認識に使用します。"}
+      </p>
+      <ul className="mb-6 list-disc space-y-2 pl-5 text-sm text-slate-300">
+        <li>{en ? "Camera data is processed for practice; raw camera video is not stored by this MVP." : "カメラデータは練習のために処理します。MVPでは生の映像を保存しません。"}</li>
+        <li>{en ? "Derived, non-identifying session events may be recorded for usability testing." : "ユーザビリティ検証のため、個人を特定しない派生セッションイベントを記録する場合があります。"}</li>
+        <li>{en ? "You can stop or leave at any time. This is supplementary practice, not a replacement for licensed instruction or real-road practice." : "いつでも停止・退出できます。これは補助練習であり、資格を持つ指導や実道練習の代替ではありません。"}</li>
+      </ul>
+      <div className="flex flex-col gap-3 sm:flex-row">
+        <button onClick={() => onChoose(true)} className="flex-1 rounded-lg bg-blue-600 px-4 py-3 font-bold hover:bg-blue-500">
+          {en ? "Agree and continue" : "同意して続ける"}
+        </button>
+        <button onClick={() => onChoose(false)} className="flex-1 rounded-lg border border-slate-500 bg-slate-700 px-4 py-3 font-bold hover:bg-slate-600">
+          {en ? "Continue without camera" : "カメラなしで続ける"}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ui/FeedbackScreen.tsx
+++ b/src/components/ui/FeedbackScreen.tsx
@@ -14,6 +14,7 @@ const STRINGS = {
     improvementPoints: '改善ポイント:',
     retry: 'もう一度挑戦',
     backToHome: 'ホームに戻る',
+    exportSession: 'セッション概要をエクスポート',
     missionFeedback: 'Mission Feedback',
     summaryMore: ' 他',
     summaryGreat: '素晴らしい走行でした',
@@ -25,6 +26,7 @@ const STRINGS = {
     improvementPoints: 'Points to improve:',
     retry: 'Try Again',
     backToHome: 'Back to Home',
+    exportSession: 'Export session summary',
     missionFeedback: 'Mission Feedback',
     summaryMore: ' and more',
     summaryGreat: 'A great drive',
@@ -43,6 +45,8 @@ export function FeedbackScreen() {
   const replayViewMode = useDrivingStore(state => state.replayViewMode); // New
   const setReplayViewMode = useDrivingStore(state => state.setReplayViewMode); // New
   const feedbackLogs = useDrivingStore(state => state.feedbackLogs); // New
+  const recordTestSessionEvent = useDrivingStore(state => state.recordTestSessionEvent);
+  const exportTestSession = useDrivingStore(state => state.exportTestSession);
 
   const analyzedRef = useRef(false);
 
@@ -106,11 +110,23 @@ export function FeedbackScreen() {
     }
 
   const handleRetry = () => {
+    recordTestSessionEvent('retry_started');
     setIsReplaying(false);
     clearReplayData();
     const retryTransition = getRetryTransition();
     setMissionState(retryTransition.missionState);
     setScreen(retryTransition.screen);
+  };
+
+  const handleExportSession = () => {
+    const json = exportTestSession();
+    if (!json) return;
+    const url = URL.createObjectURL(new Blob([json], { type: 'application/json' }));
+    const anchor = document.createElement('a');
+    anchor.href = url;
+    anchor.download = 'drivingsupport-session-summary.json';
+    anchor.click();
+    URL.revokeObjectURL(url);
   };
 
   const handleHome = () => {
@@ -302,6 +318,12 @@ export function FeedbackScreen() {
                     {t.backToHome}
                 </button>
             </div>
+            <button
+                onClick={handleExportSession}
+                className="mt-4 w-full rounded-lg border border-slate-600 px-3 py-2 text-sm text-slate-300 hover:bg-slate-700"
+            >
+                {t.exportSession}
+            </button>
         </div>
       </div>
     </div>

--- a/src/components/ui/TutorialScreen.tsx
+++ b/src/components/ui/TutorialScreen.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect } from 'react';
 import { useDrivingStore } from '@/lib/store';
 import dynamic from 'next/dynamic';
+import { CameraConsent } from './CameraConsent';
 
 // Dynamically import VisionController (avoid server-side rendering)
 const VisionController = dynamic(() => import('@/components/vision/VisionController'), { ssr: false });
@@ -141,6 +142,9 @@ export function TutorialScreen() {
     const pedalInputMode = useDrivingStore(state => state.pedalInputMode);
     const setPedalInputMode = useDrivingStore(state => state.setPedalInputMode);
     const activateKeyboardPedalFallback = useDrivingStore(state => state.activateKeyboardPedalFallback);
+    const testSession = useDrivingStore(state => state.testSession);
+    const cameraProcessingAllowed = useDrivingStore(state => state.cameraProcessingAllowed);
+    const startTestSession = useDrivingStore(state => state.startTestSession);
     const language = useDrivingStore((state) => state.language);
     const t = STRINGS[language];
 
@@ -162,18 +166,20 @@ export function TutorialScreen() {
         if (step > 1) setStep((prev) => (prev - 1) as 1 | 2 | 3 | 4 | 5);
     };
 
+    if (!testSession) {
+        return (
+            <div className="flex h-full w-full items-center justify-center bg-slate-900 p-4 text-white">
+                <CameraConsent language={language} onChoose={startTestSession} />
+            </div>
+        );
+    }
+
     return (
         <div className="relative w-full h-full bg-slate-900 text-white overflow-hidden flex flex-col items-center justify-center">
 
-            {/* Always show VisionController in the background (so the camera feed can be checked) */}
-            <div className="absolute top-0 left-0 w-full h-full">
-                <VisionController
-                    isPaused={false}
-                    onKeyboardFallback={() => {
-                        nextStep();
-                    }}
-                />
-            </div>
+            {cameraProcessingAllowed && <div className="absolute top-0 left-0 w-full h-full">
+                <VisionController isPaused={false} onKeyboardFallback={nextStep} />
+            </div>}
 
             {/* Overlay Video Removed - now a dedicated step */}
 

--- a/src/components/vision/VisionController.tsx
+++ b/src/components/vision/VisionController.tsx
@@ -40,6 +40,7 @@ export default function VisionController({
   const setGaze = useDrivingStore((state) => state.setGaze); // Gaze action
   const setGear = useDrivingStore((state) => state.setGear);
   const activateKeyboardPedalFallback = useDrivingStore((state) => state.activateKeyboardPedalFallback);
+  const recordTestSessionEvent = useDrivingStore((state) => state.recordTestSessionEvent);
   const language = useDrivingStore((state) => state.language);
 
 
@@ -144,11 +145,13 @@ export default function VisionController({
             setRecoveryKind("camera-error");
             setCameraError("This browser does not support the camera. You can drive with the keyboard (use the arrow keys to steer).");
             setDebugInfo("Camera not supported");
+            recordTestSessionEvent("camera_initialization_failed", { failureCategory: "camera-initialization" });
             return;
         }
 
         const stream = await navigator.mediaDevices.getUserMedia({ video: { width: 320, height: 240 } });
         streamRef.current = stream;
+        recordTestSessionEvent("camera_permission_granted");
         setCameraError(null);
 
         if (videoRef.current) {
@@ -168,6 +171,9 @@ export default function VisionController({
     } catch (e) {
         console.error("Camera Error:", e);
         const denied = classifyCameraFailure(e) === "denied";
+        recordTestSessionEvent(denied ? "camera_permission_denied" : "camera_initialization_failed", {
+          failureCategory: denied ? "camera-denied" : "camera-initialization",
+        });
         setRecoveryKind(denied ? "camera-denied" : "camera-error");
         setCameraError(
             denied
@@ -176,7 +182,7 @@ export default function VisionController({
         );
         setDebugInfo("Camera Error: " + String(e));
     }
-  }, [setDebugInfo, setCameraError]); // Do not add predictWebcam to the dependencies (it loops)
+  }, [recordTestSessionEvent, setDebugInfo, setCameraError]); // Do not add predictWebcam to the dependencies (it loops)
 
   // Initialization (loading MediaPipe)
   const setupMediaPipe = useCallback(async () => {
@@ -282,12 +288,13 @@ export default function VisionController({
         objectDetectorRef.current = null;
         setVisionReady(false);
         setRecoveryKind("vision-error");
+        recordTestSessionEvent("vision_initialization_failed", { failureCategory: "vision-initialization" });
         setCameraError("Vision setup failed. Retry vision setup or use keyboard pedals to continue.");
         setDebugInfo("Vision setup error: " + String(error));
       } finally {
         setIsSettingUpVision(false);
       }
-  }, [setCameraError, setDebugInfo, setVisionReady, startCamera]);
+  }, [recordTestSessionEvent, setCameraError, setDebugInfo, setVisionReady, startCamera]);
 
   const retryRecovery = useCallback(() => {
     setCameraError(null);

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -9,6 +9,15 @@ import {
   getMissedCheckpointPenalty,
 } from "./guidedTrainingContract";
 import { getKeyboardFallbackState } from "./onboardingRecovery";
+import {
+  appendTestSessionEvent,
+  createSessionId,
+  createTestSessionState,
+  finalizeTestSession,
+  serializeTestSessionSummary,
+  SessionEventType,
+  TestSessionState,
+} from "./testSession";
 
 export interface ReplayFrame {
   timestamp: number;
@@ -171,9 +180,16 @@ export interface DrivingState {
   clearedCheckpointIds: string[];
   addClearedCheckpoint: (id: string) => void;
   resetClearedCheckpoints: () => void;
+
+  // In-memory, non-identifying usability-test session instrumentation.
+  cameraProcessingAllowed: boolean;
+  testSession: TestSessionState | null;
+  startTestSession: (cameraProcessingAllowed: boolean) => void;
+  recordTestSessionEvent: (eventType: SessionEventType, payload?: { inputMode?: "camera" | "keyboard"; failureCategory?: "camera-denied" | "camera-initialization" | "vision-initialization" | "incomplete" }) => void;
+  exportTestSession: () => string | null;
 }
 
-export const useDrivingStore = create<DrivingState>((set) => ({
+export const useDrivingStore = create<DrivingState>((set, get) => ({
   // First launch (no saved language) starts on the language-selection page;
   // returning visitors (saved choice) go straight to Home. ClientApp is
   // client-only (ssr:false), so reading localStorage here is safe.
@@ -255,9 +271,9 @@ export const useDrivingStore = create<DrivingState>((set) => ({
   missionStartTime: 0,
   missionEndTime: 0,
 
-  setMissionState: (state) =>
-    set(() => {
+  setMissionState: (state) => {
       const now = Date.now();
+      const previousState = get().missionState;
       const updates: Partial<DrivingState> = { missionState: state };
 
       if (state === "active") {
@@ -266,8 +282,19 @@ export const useDrivingStore = create<DrivingState>((set) => ({
       } else if (state === "success" || state === "failed") {
         updates.missionEndTime = now;
       }
-      return updates;
-    }),
+      set(updates);
+      const session = get().testSession;
+      if (session && state !== previousState) {
+        const eventType = state === "active" ? "lesson_started" : state === "success" ? "lesson_completed" : state === "failed" ? "lesson_failed" : null;
+        if (eventType) {
+          set({ testSession: appendTestSessionEvent(session, eventType, {
+            timestamp: now,
+            lessonId: get().currentLesson,
+            ...(eventType === "lesson_failed" ? { failureCategory: "incomplete" as const } : {}),
+          }) });
+        }
+      }
+    },
 
   deviationPenalty: 0,
   addDeviationPenalty: (amount) =>
@@ -429,14 +456,22 @@ export const useDrivingStore = create<DrivingState>((set) => ({
     if (typeof window !== "undefined") localStorage.setItem("pedalInputMode", mode);
     if (mode === "camera") {
       set({ pedalInputMode: mode, calibrationStage: "idle", footCalibration: null });
-      return;
+    } else {
+      set(getKeyboardFallbackState());
     }
-    set(getKeyboardFallbackState());
+    const session = get().testSession;
+    if (session && get().pedalInputMode !== session.selectedInputMode) {
+      set({ testSession: appendTestSessionEvent(session, "input_mode_selected", { inputMode: mode, timestamp: Date.now(), lessonId: get().currentLesson }) });
+    }
   },
   activateKeyboardPedalFallback: () => {
     const fallbackState = getKeyboardFallbackState();
     if (typeof window !== "undefined") localStorage.setItem("pedalInputMode", fallbackState.pedalInputMode);
     set(fallbackState);
+    const session = get().testSession;
+    if (session && session.selectedInputMode !== "keyboard") {
+      set({ testSession: appendTestSessionEvent(session, "input_mode_selected", { inputMode: "keyboard", timestamp: Date.now(), lessonId: get().currentLesson }) });
+    }
   },
   startCalibration: () =>
     set({
@@ -477,4 +512,31 @@ export const useDrivingStore = create<DrivingState>((set) => ({
     clearedCheckpointIds: [...state.clearedCheckpointIds, id]
   })),
   resetClearedCheckpoints: () => set({ clearedCheckpointIds: [] }),
+
+  cameraProcessingAllowed: false,
+  testSession: null,
+  startTestSession: (cameraProcessingAllowed) => {
+    const inputMode = cameraProcessingAllowed ? get().pedalInputMode : "keyboard";
+    const state = createTestSessionState({
+      sessionId: createSessionId(),
+      startedAt: Date.now(),
+      consentAccepted: cameraProcessingAllowed,
+      inputMode,
+      lessonId: get().currentLesson,
+    });
+    set({ cameraProcessingAllowed, testSession: state });
+    if (!cameraProcessingAllowed) get().activateKeyboardPedalFallback();
+  },
+  recordTestSessionEvent: (eventType, payload) => {
+    const session = get().testSession;
+    if (!session) return;
+    set({ testSession: appendTestSessionEvent(session, eventType, { ...payload, timestamp: Date.now(), lessonId: get().currentLesson }) });
+  },
+  exportTestSession: () => {
+    const session = get().testSession;
+    if (!session) return null;
+    const summary = finalizeTestSession(session, Date.now());
+    set({ testSession: summary });
+    return serializeTestSessionSummary(summary);
+  },
 }));

--- a/src/lib/testSession.ts
+++ b/src/lib/testSession.ts
@@ -1,0 +1,120 @@
+export const TEST_SESSION_SCHEMA_VERSION = 1 as const;
+
+export type SessionInputMode = "camera" | "keyboard";
+export type CameraPermissionOutcome = "unknown" | "granted" | "denied" | "failed";
+export type FailureCategory = "camera-denied" | "camera-initialization" | "vision-initialization" | "incomplete";
+export type SessionEventType =
+  | "consent_accepted"
+  | "camera_permission_granted"
+  | "camera_permission_denied"
+  | "camera_initialization_failed"
+  | "vision_initialization_failed"
+  | "input_mode_selected"
+  | "lesson_started"
+  | "lesson_completed"
+  | "lesson_failed"
+  | "retry_started"
+  | "session_completed";
+
+export interface TestSessionEvent {
+  schemaVersion: typeof TEST_SESSION_SCHEMA_VERSION;
+  sessionId: string;
+  eventType: SessionEventType;
+  timestampMs: number;
+  lessonId?: string;
+  inputMode?: SessionInputMode;
+  failureCategory?: FailureCategory;
+}
+
+export interface TestSessionState {
+  schemaVersion: typeof TEST_SESSION_SCHEMA_VERSION;
+  sessionId: string;
+  startedAt: number;
+  consentAccepted: boolean;
+  cameraPermissionOutcome: CameraPermissionOutcome;
+  selectedInputMode: SessionInputMode;
+  lessonId: string;
+  completed: boolean;
+  retryCount: number;
+  failureCategories: FailureCategory[];
+  events: TestSessionEvent[];
+}
+
+export type TestSessionSummary = Omit<TestSessionState, "startedAt"> & {
+  startedAt: number;
+  endedAt: number;
+};
+
+export function canStartCamera(consentAccepted: boolean): boolean {
+  return consentAccepted;
+}
+
+export function createSessionId(randomUuid: () => string = () => globalThis.crypto?.randomUUID?.() ?? ""): string {
+  const id = randomUuid();
+  if (id) return id;
+  return `session-${Math.random().toString(36).slice(2)}-${Date.now().toString(36)}`;
+}
+
+export function createTestSessionState(options: {
+  sessionId: string;
+  startedAt: number;
+  consentAccepted: boolean;
+  inputMode: SessionInputMode;
+  lessonId: string;
+}): TestSessionState {
+  const state: TestSessionState = {
+    schemaVersion: TEST_SESSION_SCHEMA_VERSION,
+    sessionId: options.sessionId,
+    startedAt: options.startedAt,
+    consentAccepted: options.consentAccepted,
+    cameraPermissionOutcome: "unknown",
+    selectedInputMode: options.inputMode,
+    lessonId: options.lessonId,
+    completed: false,
+    retryCount: 0,
+    failureCategories: [],
+    events: [],
+  };
+  return options.consentAccepted
+    ? appendTestSessionEvent(state, "consent_accepted", { timestamp: options.startedAt })
+    : appendTestSessionEvent(state, "input_mode_selected", { inputMode: "keyboard", timestamp: options.startedAt });
+}
+
+export function appendTestSessionEvent(
+  state: TestSessionState,
+  eventType: SessionEventType,
+  payload: { timestamp?: number; lessonId?: string; inputMode?: SessionInputMode; failureCategory?: FailureCategory } = {},
+): TestSessionState {
+  const timestampMs = Math.max(0, (payload.timestamp ?? Date.now()) - state.startedAt);
+  const event: TestSessionEvent = {
+    schemaVersion: TEST_SESSION_SCHEMA_VERSION,
+    sessionId: state.sessionId,
+    eventType,
+    timestampMs,
+    ...(payload.lessonId ? { lessonId: payload.lessonId } : {}),
+    ...(payload.inputMode ? { inputMode: payload.inputMode } : {}),
+    ...(payload.failureCategory ? { failureCategory: payload.failureCategory } : {}),
+  };
+  const next = { ...state, events: [...state.events, event] };
+  if (eventType === "camera_permission_granted") next.cameraPermissionOutcome = "granted";
+  if (eventType === "camera_permission_denied") next.cameraPermissionOutcome = "denied";
+  if (eventType === "camera_initialization_failed") next.cameraPermissionOutcome = "failed";
+  if (eventType === "input_mode_selected" && payload.inputMode) next.selectedInputMode = payload.inputMode;
+  if (eventType === "lesson_completed") next.completed = true;
+  if (eventType === "lesson_failed" && payload.failureCategory && !next.failureCategories.includes(payload.failureCategory)) {
+    next.failureCategories = [...next.failureCategories, payload.failureCategory];
+  }
+  if (eventType === "retry_started") next.retryCount += 1;
+  return next;
+}
+
+export function finalizeTestSession(state: TestSessionState, endedAt: number): TestSessionSummary {
+  const completed = state.events.some((event) => event.eventType === "session_completed")
+    ? state
+    : appendTestSessionEvent(state, "session_completed", { timestamp: endedAt });
+  return { ...completed, endedAt };
+}
+
+export function serializeTestSessionSummary(summary: TestSessionSummary): string {
+  return JSON.stringify(summary, null, 2);
+}

--- a/tests/test-session.test.ts
+++ b/tests/test-session.test.ts
@@ -1,0 +1,58 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  appendTestSessionEvent,
+  canStartCamera,
+  createTestSessionState,
+  finalizeTestSession,
+} from "../src/lib/testSession.js";
+
+const base = () => createTestSessionState({
+  sessionId: "session-test-1",
+  startedAt: 1_000,
+  consentAccepted: true,
+  inputMode: "camera",
+  lessonId: "left-turn",
+});
+
+test("camera processing requires explicit consent", () => {
+  assert.equal(canStartCamera(false), false);
+  assert.equal(canStartCamera(true), true);
+});
+
+test("accepted consent and camera permission are derived events", () => {
+  const state = appendTestSessionEvent(base(), "camera_permission_granted", { timestamp: 1_100 });
+  assert.equal(state.events[0].eventType, "consent_accepted");
+  assert.equal(state.cameraPermissionOutcome, "granted");
+  assert.deepEqual(state.events[1], {
+    schemaVersion: 1,
+    sessionId: "session-test-1",
+    eventType: "camera_permission_granted",
+    timestampMs: 100,
+  });
+});
+
+test("denied camera and keyboard fallback remain bounded", () => {
+  const denied = appendTestSessionEvent(base(), "camera_permission_denied", {
+    timestamp: 1_200,
+    failureCategory: "camera-denied",
+  });
+  const keyboard = appendTestSessionEvent(denied, "input_mode_selected", { timestamp: 1_300, inputMode: "keyboard" });
+  assert.equal(keyboard.cameraPermissionOutcome, "denied");
+  assert.equal(keyboard.selectedInputMode, "keyboard");
+  assert.equal(keyboard.events.at(-1)?.inputMode, "keyboard");
+});
+
+test("lesson completion and retry are represented in the summary", () => {
+  let state = appendTestSessionEvent(base(), "lesson_started", { timestamp: 1_400 });
+  state = appendTestSessionEvent(state, "retry_started", { timestamp: 1_500 });
+  state = appendTestSessionEvent(state, "lesson_completed", { timestamp: 1_600 });
+  const summary = finalizeTestSession(state, 1_700);
+  assert.equal(summary.completed, true);
+  assert.equal(summary.retryCount, 1);
+  assert.equal(summary.events.at(-1)?.eventType, "session_completed");
+  const serialized = JSON.stringify(summary);
+  for (const forbidden of ["video", "frame", "image", "landmarks", "face", "handLandmarks", "poseLandmarks", "email", "name", "userId", "firebaseUid", "ipAddress"]) {
+    assert.equal(serialized.includes(forbidden), false, `forbidden field: ${forbidden}`);
+  }
+});

--- a/tsconfig.tests.json
+++ b/tsconfig.tests.json
@@ -11,7 +11,9 @@
   "include": [
     "src/lib/guidedTrainingContract.ts",
     "src/lib/onboardingRecovery.ts",
+    "src/lib/testSession.ts",
     "tests/guided-training-regression.test.ts",
-    "tests/onboarding-recovery.test.ts"
+    "tests/onboarding-recovery.test.ts",
+    "tests/test-session.test.ts"
   ]
 }


### PR DESCRIPTION
Closes #30

## Summary
- add an explicit JA/EN camera consent gate before VisionController, with guest keyboard fallback
- record a typed, non-identifying in-memory test-session summary from existing camera, input, lesson, retry, and completion transitions
- add explicit JSON export plus public privacy documentation and deterministic schema tests

## Privacy boundary
- no raw camera frames, recorded video, screenshots, MediaPipe landmark arrays, identity, account IDs, network identifiers, or free text enter the session schema
- no Firebase event upload and no indefinite localStorage event log
- the session ID is random and non-identifying

## Verification
- `npm ci`
- `npm run test:guided`
- `npm run lint` (0 errors; existing Hook dependency warnings)
- `npm run type-check`
- `git diff --check`

## Runtime notes
- consent is required before camera processing starts
- camera-denied, initialization-failed, and keyboard fallback states remain distinguishable
- existing camera, scoring, retry, and Firebase history behavior is preserved

## Review checklist
- [x] Issue scope only
- [x] Tests and documentation updated
- [x] Guest flow remains available
- [x] Draft PR; do not merge automatically